### PR TITLE
Refactor code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,6 @@ IncludeCategories:
     Priority:        3
   - Regex:           '.*'
     Priority:        4
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakTemplateDeclarations: true
 BreakConstructorInitializers: BeforeComma
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,6 +58,10 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.ClassMemberSuffix
     value: _
+  - key: readability-identifier-naming.ClassConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassConstantPrefix
+    value: k
   - key: readability-identifier-naming.EnumConstantCase
     value: CamelCase
   - key: readability-identifier-naming.EnumConstantPrefix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Install dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 21
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libgtest-dev g++ clang-format-21
+          sudo apt-get install -y build-essential cmake libgtest-dev g++ clang-format-19
           pip install cmake-format
 
       - name: Install dependencies (macOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ project(
     LANGUAGES CXX
 )
 
-set(CMAKE_CXX_STANDARD 17)
-
 add_subdirectory(tinyxml2)
 
 add_library(COLA SHARED COLA.cc)
@@ -44,7 +42,7 @@ set(COLA_CMAKE_CXX_CLANG_TIDY
 
 set_target_properties(
     COLA
-    PROPERTIES PUBLIC_HEADER "COLA.hh;LorentzVector.hh"
+    PROPERTIES PUBLIC_HEADER "COLA.hh"
                VERSION "${COLA_VERSION}"
                SOVERSION "${COLA_VERSION_MAJOR}"
                CXX_CLANG_TIDY "${COLA_CMAKE_CXX_CLANG_TIDY}"
@@ -72,6 +70,13 @@ write_basic_package_version_file(
 )
 
 install(EXPORT COLAExport DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/COLA)
+
+install(
+    DIRECTORY ${PROJECT_SOURCE_DIR}/COLA
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING
+    PATTERN "*.hh"
+)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/COLAConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/COLAConfigVersion.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,13 +94,6 @@ install(
     PATTERN "*.cmake"
 )
 
-install(
-    DIRECTORY cmake/
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/COLA/cmake
-    FILES_MATCHING
-    PATTERN "*.cmake"
-)
-
 enable_testing()
 if (BUILD_TESTING)
     add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ project(
 
 set(CMAKE_CXX_STANDARD 17)
 
-# Add internal dependency to build
 add_subdirectory(tinyxml2)
 
 add_library(COLA SHARED COLA.cc)

--- a/COLA.cc
+++ b/COLA.cc
@@ -20,150 +20,216 @@
 
 #include "COLA.hh"
 
-#include <tinyxml2.h>
-
 #include <cmath>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <utility>
+
+#include <tinyxml2.h>
 
 namespace {
-  std::map<std::string, std::string> GetNameAndParams(const tinyxml2::XMLElement* element, std::string& name) {
-    const auto* current_attribute = element->FindAttribute("name");
-    name = current_attribute->Value();
-    std::cout << "filter name: " + name + "\nparams:\n";
-    current_attribute = current_attribute->Next();
-    std::map<std::string, std::string> params;
-    while (current_attribute != nullptr) {
-      params.emplace(current_attribute->Name(), current_attribute->Value());
-      std::cout << current_attribute->Name() << ": " << current_attribute->Value() << '\n';
-      current_attribute = current_attribute->Next();
+    static const std::string FILTER_NAME_ATTRIBUTE = "name";
+
+    std::unordered_map<std::string, std::string> CollectAttributes(const tinyxml2::XMLElement* element) {
+        std::unordered_map<std::string, std::string> params;
+
+        for (const auto* attribute = element->FirstAttribute(); attribute != nullptr; attribute = attribute->Next()) {
+            params.emplace(attribute->Name(), attribute->Value());
+        }
+
+        return params;
     }
-    return params;
-  }
-}  // namespace
+
+    std::unique_ptr<cola::VFilter> CreateFilterFromNode(
+        const tinyxml2::XMLElement* element,
+        const std::unordered_map<std::string, std::unique_ptr<cola::VFactory>>& factoryMap) {
+        auto params = CollectAttributes(element);
+
+        const auto filterName = std::move(params.at(FILTER_NAME_ATTRIBUTE));
+        params.erase(FILTER_NAME_ATTRIBUTE);
+
+        // log attributes
+        {
+            std::cout << "filter name: " + filterName + "\nparams:\n";
+
+            for (const auto& [name, value] : params) {
+                std::cout << name << ": " << value << '\n';
+            }
+        }
+
+        return factoryMap.at(filterName)->Create(params);
+    }
+
+    template <typename Base>
+    std::unique_ptr<Base> DynamicPointerCast(std::unique_ptr<cola::VFilter>&& ptr) {
+        cola::VFilter* raw = ptr.release();
+        auto* derived = dynamic_cast<Base*>(raw);
+        if (derived == nullptr) {
+            delete raw;
+            throw std::runtime_error("DynamicPointerCast: filter type mismatch");
+        }
+        return std::unique_ptr<Base>(derived);
+    }
+} // namespace
 
 namespace cola {
 
-  // converters
+    // converters
 
-  AZ PdgToAz(int pdgCode) {
-    switch (pdgCode) {
-      case 2112:
-        return {1, 0};
-      case 2212:
-        return {1, 1};
-      default: {
-        AZ data = {0, 0};
-        pdgCode /= 10;
-        for (int i = 0; i < 3; i++) {
-          data.first += pdgCode % 10 * static_cast<std::uint16_t>(pow(10, i));
-          pdgCode /= 10;
+    AZ PdgToAz(int pdgCode) {
+        switch (pdgCode) {
+        case 2112:
+            return {1, 0};
+        case 2212:
+            return {1, 1};
+        default: {
+            AZ data = {0, 0};
+            pdgCode /= 10;
+            for (int i = 0; i < 3; i++) {
+                data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+                pdgCode /= 10;
+            }
+            for (int i = 0; i < 3; i++) {
+                data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+                pdgCode /= 10;
+            }
+            return data;
         }
-        for (int i = 0; i < 3; i++) {
-          data.second += pdgCode % 10 * static_cast<std::uint16_t>(pow(10, i));
-          pdgCode /= 10;
         }
-        return data;
-      }
-    }
-  }
-
-  int AZToPdg(AZ data) {
-    if (data.first == 1 && data.second == 0) {
-      return 2112;
-    }
-    if (data.first == 1 && data.second == 1) {
-      return 2212;
-    }
-    return 1000000000 + data.first * 10 + data.second * 10000;
-  }
-
-  AZ Particle::GetAz() const { return PdgToAz(pdgCode); }
-
-  // operators
-
-  std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& generator,
-                                       const std::unique_ptr<VConverter>& converter) {
-    return (*converter)((*generator)());
-  }
-  std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& data,
-                                       const std::unique_ptr<VConverter>& converter) {
-    return (*converter)(std::move(data));
-  }
-  void operator|(std::unique_ptr<EventData>&& data, const std::unique_ptr<VWriter>& writer) {
-    (*writer)(std::move(data));
-  }
-
-  // MetaProcessor
-
-  MetaProcessor::MetaProcessor(std::map<std::string, std::pair<std::unique_ptr<VFactory>, FilterType>>& filterMap) {
-    for (auto& item : filterMap) {
-      Reg(std::move(item.second.first), item.first, item.second.second);
-    }
-  }
-
-  void MetaProcessor::Reg(std::unique_ptr<VFactory>&& factory, const std::string& name, const FilterType type) {
-    switch (type) {
-      case FilterType::kGenerator:
-        RegGen(std::move(factory), name);
-        break;
-      case FilterType::kConverter:
-        RegConv(std::move(factory), name);
-        break;
-      case FilterType::kWriter:
-        RegWrite(std::move(factory), name);
-        break;
-      default:
-        throw std::domain_error("ERROR in MetaProcessor: No such type of filter.");
-    }
-  }
-
-  FilterEnsemble MetaProcessor::Parse(const std::string& fName) const {
-    using namespace tinyxml2;
-    std::cout << "Parsing XML file:" << '\n';
-    XMLDocument file;
-    auto code = file.LoadFile(fName.c_str());
-    if (code != XML_SUCCESS) {
-      throw std::runtime_error("ERROR in MetaProcessor: Couldn't open file `" + fName +
-                               "`.\nError code (tinyxml2): " + std::to_string(code));
     }
 
-    FilterEnsemble ensemble;
-
-    auto* current_element = file.RootElement()->FirstChildElement("generator");
-    std::string name;
-    auto params = GetNameAndParams(current_element, name);
-    ensemble.generator = std::unique_ptr<VGenerator>(dynamic_cast<VGenerator*>(generatorMap_.at(name)->Create(params)));
-    params.clear();
-
-    current_element = current_element->NextSiblingElement();
-    while (current_element->Name() != std::string("writer")) {
-      params = GetNameAndParams(current_element, name);
-      ensemble.converters.push_back(
-          std::unique_ptr<VConverter>(dynamic_cast<VConverter*>(converterMap_.at(name)->Create(params))));
-      params.clear();
-      current_element = current_element->NextSiblingElement();
+    int AZToPdg(AZ data) {
+        if (data.first == 1 && data.second == 0) {
+            return 2112;
+        }
+        if (data.first == 1 && data.second == 1) {
+            return 2212;
+        }
+        return 1000000000 + data.first * 10 + data.second * 10000;
     }
 
-    params = GetNameAndParams(current_element, name);
-    ensemble.writer = std::unique_ptr<VWriter>(dynamic_cast<VWriter*>(writerMap_.at(name)->Create(params)));
-    return ensemble;
-  }
-
-  // Run manager
-
-  void ColaRunManager::Run(int n) const {
-    for (int k = 0; k < n; k++) {
-      auto event = (*(filterEnsemble_.generator))();
-      for (const auto& converter : filterEnsemble_.converters) {
-        event = std::move(event) | converter;
-      }
-      std::move(event) | filterEnsemble_.writer;
+    AZ Particle::GetAz() const {
+        return PdgToAz(pdgCode);
     }
-  }
 
-}  // namespace cola
+    // operators
+
+    std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& generator,
+                                         const std::unique_ptr<VConverter>& converter) {
+        return (*converter)((*generator)());
+    }
+    std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& data,
+                                         const std::unique_ptr<VConverter>& converter) {
+        return (*converter)(std::move(data));
+    }
+    void operator|(std::unique_ptr<EventData>&& data, const std::unique_ptr<VWriter>& writer) {
+        (*writer)(std::move(data));
+    }
+
+    // Metaprocessor
+
+    MetaProcessor::MetaProcessor(FactoryMap&& filterMap) {
+        for (auto& [name, factory] : filterMap) {
+            Register(std::move(factory), name);
+        }
+    }
+
+    void MetaProcessor::Register(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+        switch (factory->GetFilterType()) {
+            case FilterType::GENERATOR: {
+                RegisterGenerator(std::move(factory), name);
+                break;
+            }
+            case FilterType::CONVERTER: {
+                RegisterConverter(std::move(factory), name);
+                break;
+            }
+            case FilterType::WRITER: {
+                RegisterWriter(std::move(factory), name);
+                break;
+            }
+            default: {
+                throw std::domain_error("ERROR in MetaProcessor: No such type of filter.");
+            }
+        }
+    }
+
+    FilterEnsemble MetaProcessor::Parse(const std::string& fName) const {
+        using namespace tinyxml2;
+        std::cout << "Parsing XML file:" << '\n';
+        XMLDocument file;
+        auto code = file.LoadFile(fName.c_str());
+        if (code != XML_SUCCESS) {
+            throw std::runtime_error("ERROR in MetaProcessor: Couldn't open file `" + fName +
+                                     "`.\nError code (tinyxml2): " + std::to_string(code));
+        }
+
+        FilterEnsemble ensemble;
+        const tinyxml2::XMLNode* root = file.RootElement();
+        if (root == nullptr) {
+            throw std::runtime_error("ERROR in MetaProcessor: Empty XML document");
+        }
+
+        for (const tinyxml2::XMLNode* node = root->FirstChild(); node != nullptr; node = node->NextSibling()) {
+            const auto* elem = node->ToElement();
+            if (elem == nullptr) {
+                continue;
+            }
+
+            if (ensemble.writer != nullptr) {
+                throw std::runtime_error("Unexpected element after writer");
+            }
+
+            const std::string tag(elem->Name());
+
+            if (tag == "generator") {
+                if (ensemble.generator != nullptr) {
+                    throw std::runtime_error("Found multiple generators");
+                }
+                ensemble.generator =
+                    DynamicPointerCast<VGenerator>(CreateFilterFromNode(elem, generatorMap_));
+                continue;
+            }
+
+            if (ensemble.generator == nullptr) {
+                throw std::runtime_error("Exactly one generator must be described first");
+            }
+
+            if (tag == "converter") {
+                ensemble.converters.emplace_back(
+                    DynamicPointerCast<VConverter>(CreateFilterFromNode(elem, converterMap_)));
+                continue;
+            }
+
+            if (tag == "writer") {
+                ensemble.writer = DynamicPointerCast<VWriter>(CreateFilterFromNode(elem, writerMap_));
+                continue;
+            }
+
+            throw std::runtime_error("Unknown node: " + tag);
+        }
+
+        if (ensemble.generator == nullptr) {
+            throw std::runtime_error("Missing generator element");
+        }
+        if (ensemble.writer == nullptr) {
+            throw std::runtime_error("Missing writer element");
+        }
+
+        return ensemble;
+    }
+
+    // Run manager
+
+    void ColaRunManager::Run(int n) const {
+        for (auto k = 0; k < n; ++k) {
+            auto event = (*(filterEnsemble_.generator))();
+            for (const auto& converter : filterEnsemble_.converters) {
+                event = std::move(event) | converter;
+            }
+            std::move(event) | filterEnsemble_.writer;
+        }
+    }
+
+} // namespace cola

--- a/COLA.cc
+++ b/COLA.cc
@@ -280,8 +280,7 @@ namespace cola {
       for (const auto& entry : std::filesystem::directory_iterator(cola_entry.path())) {
         if (entry.path().extension() == ".so" || entry.path().extension() == ".dylib") {
           if (auto* library_handler = dlopen(entry.path().c_str(), RTLD_LAZY); library_handler != nullptr) {
-            if (auto* raw_function_ptr = dlsym(library_handler, function_name.c_str());
-                raw_function_ptr != nullptr) {
+            if (auto* raw_function_ptr = dlsym(library_handler, function_name.c_str()); raw_function_ptr != nullptr) {
               auto* function_ptr = reinterpret_cast<LoadModuleFunction*>(raw_function_ptr);
               return std::unique_ptr<cola::VModule>(function_ptr());
             }

--- a/COLA.cc
+++ b/COLA.cc
@@ -131,7 +131,7 @@ namespace cola {
     (*writer)(std::move(data));
   }
 
-  // Metaprocessor
+  // MetaProcessor
 
   MetaProcessor::MetaProcessor(FactoryMap&& filterMap) {
     for (auto& [name, factory] : filterMap) {

--- a/COLA.cc
+++ b/COLA.cc
@@ -20,9 +20,11 @@
 
 #include "COLA.hh"
 
+#include <dlfcn.h>
+#include <tinyxml2.h>
+
 #include <cmath>
 #include <cstdint>
-#include <dlfcn.h>
 #include <filesystem>
 #include <iostream>
 #include <iterator>
@@ -30,273 +32,269 @@
 #include <string>
 #include <string_view>
 
-#include <tinyxml2.h>
-
 using namespace std::string_view_literals;
 
 namespace {
-    static const std::string FILTER_NAME_ATTRIBUTE = "name";
+  const std::string filter_name_attribute = "name";
 
-    std::unordered_map<std::string, std::string> CollectAttributes(const tinyxml2::XMLElement* element) {
-        std::unordered_map<std::string, std::string> params;
+  std::unordered_map<std::string, std::string> CollectAttributes(const tinyxml2::XMLElement* element) {
+    std::unordered_map<std::string, std::string> params;
 
-        for (const auto* attribute = element->FirstAttribute(); attribute != nullptr; attribute = attribute->Next()) {
-            params.emplace(attribute->Name(), attribute->Value());
-        }
-
-        return params;
+    for (const auto* attribute = element->FirstAttribute(); attribute != nullptr; attribute = attribute->Next()) {
+      params.emplace(attribute->Name(), attribute->Value());
     }
 
-    std::unique_ptr<cola::VFilter> CreateFilterFromNode(
-        const tinyxml2::XMLElement* element,
-        const std::unordered_map<std::string, std::unique_ptr<cola::VFactory>>& factoryMap) {
-        auto params = CollectAttributes(element);
+    return params;
+  }
 
-        const auto filterName = std::move(params.at(FILTER_NAME_ATTRIBUTE));
-        params.erase(FILTER_NAME_ATTRIBUTE);
+  std::unique_ptr<cola::VFilter> CreateFilterFromNode(
+      const tinyxml2::XMLElement* element,
+      const std::unordered_map<std::string, std::unique_ptr<cola::VFactory>>& factoryMap) {
+    auto params = CollectAttributes(element);
 
-        // log attributes
-        {
-            std::cout << "filter name: " + filterName + "\nparams:\n";
+    const auto filter_name = std::move(params.at(filter_name_attribute));
+    params.erase(filter_name_attribute);
 
-            for (const auto& [name, value] : params) {
-                std::cout << name << ": " << value << '\n';
-            }
-        }
+    // log attributes
+    {
+      std::cout << "filter name: " + filter_name + "\nparams:\n";
 
-        return factoryMap.at(filterName)->Create(params);
+      for (const auto& [name, value] : params) {
+        std::cout << name << ": " << value << '\n';
+      }
     }
 
-    template <typename Target, typename Source>
-    std::unique_ptr<Target> DynamicPointerCast(std::unique_ptr<Source>&& ptr) {
-        auto result = std::unique_ptr<Target>(&dynamic_cast<Target&>(*ptr.get()));
-        ptr.release();
-        return result;
-    }
+    return factoryMap.at(filter_name)->Create(params);
+  }
 
-    std::string ReadAll(std::istream& is) {
-        return std::string(std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>());
-    }
-} // namespace
+  template <typename Target, typename Source>
+  std::unique_ptr<Target> DynamicPointerCast(std::unique_ptr<Source>&& ptr) {
+    auto result = std::unique_ptr<Target>(&dynamic_cast<Target&>(*ptr.get()));
+    ptr.release();
+    return result;
+  }
+
+  std::string ReadAll(std::istream& is) {
+    return std::string(std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>());
+  }
+}  // namespace
 
 namespace cola {
 
-    // converters
+  // converters
 
-    AZ PdgToAZ(int pdgCode) {
-        switch (pdgCode) {
-            case 2112:
-                return {1, 0};
-            case 2212:
-                return {1, 1};
-            default: {
-                AZ data = {0, 0};
-                pdgCode /= 10;
-                for (int i = 0; i < 3; i++) {
-                    data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
-                    pdgCode /= 10;
-                }
-                for (int i = 0; i < 3; i++) {
-                    data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
-                    pdgCode /= 10;
-                }
-                return data;
-            }
+  AZ PdgToAZ(int pdgCode) {
+    switch (pdgCode) {
+      case 2112:
+        return {1, 0};
+      case 2212:
+        return {1, 1};
+      default: {
+        AZ data = {0, 0};
+        pdgCode /= 10;
+        for (int i = 0; i < 3; i++) {
+          data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+          pdgCode /= 10;
         }
+        for (int i = 0; i < 3; i++) {
+          data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+          pdgCode /= 10;
+        }
+        return data;
+      }
+    }
+  }
+
+  int AZToPdg(AZ data) {
+    if (data.first == 1 && data.second == 0) {
+      return 2112;
+    }
+    if (data.first == 1 && data.second == 1) {
+      return 2212;
+    }
+    return 1000000000 + data.first * 10 + data.second * 10000;
+  }
+
+  AZ Particle::GetAZ() const { return PdgToAZ(pdgCode); }
+
+  // operators
+
+  std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& generator,
+                                       const std::unique_ptr<VConverter>& converter) {
+    return (*converter)((*generator)());
+  }
+  std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& data,
+                                       const std::unique_ptr<VConverter>& converter) {
+    return (*converter)(std::move(data));
+  }
+  void operator|(std::unique_ptr<EventData>&& data, const std::unique_ptr<VWriter>& writer) {
+    (*writer)(std::move(data));
+  }
+
+  // Metaprocessor
+
+  MetaProcessor::MetaProcessor(FactoryMap&& filterMap) {
+    for (auto& [name, factory] : filterMap) {
+      Register(std::move(factory), name);
+    }
+  }
+
+  void MetaProcessor::Register(std::unique_ptr<VFactory>&& factory, const std::optional<std::string>& name) {
+    auto filter_name = name.value_or(factory->GetFilterName());
+    switch (factory->GetFilterType()) {
+      case FilterType::kGenerator: {
+        RegisterGenerator(std::move(factory), filter_name);
+        break;
+      }
+      case FilterType::kConverter: {
+        RegisterConverter(std::move(factory), filter_name);
+        break;
+      }
+      case FilterType::kWriter: {
+        RegisterWriter(std::move(factory), filter_name);
+        break;
+      }
+      default: {
+        throw std::domain_error("ERROR in MetaProcessor: No such type of filter.");
+      }
+    }
+  }
+
+  FilterEnsemble MetaProcessor::Parse(const std::string& fName) const {
+    using namespace tinyxml2;
+    std::cout << "Parsing XML file:" << '\n';
+    tinyxml2::XMLDocument file;
+    auto code = file.LoadFile(fName.c_str());
+    if (code != tinyxml2::XML_SUCCESS) {
+      throw std::runtime_error("ERROR in MetaProcessor: Couldn't open file `" + fName +
+                               "`.\nError code (tinyxml2): " + std::to_string(code));
     }
 
-    int AZToPdg(AZ data) {
-        if (data.first == 1 && data.second == 0) {
-            return 2112;
-        }
-        if (data.first == 1 && data.second == 1) {
-            return 2212;
-        }
-        return 1000000000 + data.first * 10 + data.second * 10000;
+    return BuildFilterEnsemble(file);
+  }
+
+  FilterEnsemble MetaProcessor::Parse(std::istream& contents) const {
+    tinyxml2::XMLDocument document;
+    auto str = ReadAll(contents);
+    auto code = document.Parse(str.c_str());
+    if (code != tinyxml2::XML_SUCCESS) {
+      throw std::runtime_error("ERROR in MetaProcessor: bad XML file.\nError code (tinyxml2): " + std::to_string(code));
     }
 
-    AZ Particle::GetAZ() const {
-        return PdgToAZ(pdgCode);
-    }
+    return BuildFilterEnsemble(document);
+  }
 
-    // operators
+  FilterEnsemble MetaProcessor::BuildFilterEnsemble(const tinyxml2::XMLDocument& document) const {
+    using namespace tinyxml2;
+    std::unique_ptr<VGenerator> generator;
+    std::vector<std::unique_ptr<VConverter>> converters;
+    std::unique_ptr<VWriter> writer;
 
-    std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& generator,
-                                         const std::unique_ptr<VConverter>& converter) {
-        return (*converter)((*generator)());
-    }
-    std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& data,
-                                         const std::unique_ptr<VConverter>& converter) {
-        return (*converter)(std::move(data));
-    }
-    void operator|(std::unique_ptr<EventData>&& data, const std::unique_ptr<VWriter>& writer) {
-        (*writer)(std::move(data));
-    }
-
-    // Metaprocessor
-
-    MetaProcessor::MetaProcessor(FactoryMap&& filterMap) {
-        for (auto& [name, factory] : filterMap) {
-            Register(std::move(factory), name);
+    for (const auto* elem = document.RootElement()->FirstChildElement(); elem != nullptr;
+         elem = elem->NextSiblingElement()) {
+      if (elem->Name() == "generator"sv) {
+        if (generator != nullptr) {
+          throw std::runtime_error("Found multiple generators");
         }
+        generator = DynamicPointerCast<VGenerator>(CreateFilterFromNode(elem, generatorMap_));
+        continue;
+      }
+      if (generator == nullptr) {
+        throw std::runtime_error("Exactly one generator must be described first");
+      }
+      if (writer != nullptr) {
+        throw std::runtime_error("Exactly one writer must be described last");
+      }
+
+      if (elem->Name() == "converter"sv) {
+        converters.emplace_back(DynamicPointerCast<VConverter>(CreateFilterFromNode(elem, converterMap_)));
+        continue;
+      }
+
+      if (elem->Name() == "writer"sv) {
+        writer = DynamicPointerCast<VWriter>(CreateFilterFromNode(elem, writerMap_));
+        continue;
+      }
+
+      throw std::runtime_error(std::string("Unknown node: ") + elem->Name());
     }
 
-    void MetaProcessor::Register(std::unique_ptr<VFactory>&& factory, const std::optional<std::string>& name) {
-        auto filterName = name.value_or(factory->GetFilterName());
-        switch (factory->GetFilterType()) {
-            case FilterType::GENERATOR: {
-                RegisterGenerator(std::move(factory), filterName);
-                break;
-            }
-            case FilterType::CONVERTER: {
-                RegisterConverter(std::move(factory), filterName);
-                break;
-            }
-            case FilterType::WRITER: {
-                RegisterWriter(std::move(factory), filterName);
-                break;
-            }
-            default: {
-                throw std::domain_error("ERROR in MetaProcessor: No such type of filter.");
-            }
-        }
+    if (generator == nullptr) {
+      throw std::runtime_error("No generator found");
     }
 
-    FilterEnsemble MetaProcessor::Parse(const std::string& fName) const {
-        using namespace tinyxml2;
-        std::cout << "Parsing XML file:" << '\n';
-        tinyxml2::XMLDocument file;
-        auto code = file.LoadFile(fName.c_str());
-        if (code != tinyxml2::XML_SUCCESS) {
-            throw std::runtime_error("ERROR in MetaProcessor: Couldn't open file `" + fName +
-                                     "`.\nError code (tinyxml2): " + std::to_string(code));
-        }
-
-        return BuildFilterEnsemble(file);
+    if (writer == nullptr) {
+      throw std::runtime_error("No writer found");
     }
 
-    FilterEnsemble MetaProcessor::Parse(std::istream& contents) const {
-        tinyxml2::XMLDocument document;
-        auto str = ReadAll(contents);
-        auto code = document.Parse(str.c_str());
-        if (code != tinyxml2::XML_SUCCESS) {
-            throw std::runtime_error("ERROR in MetaProcessor: bad XML file.\nError code (tinyxml2): " +
-                                     std::to_string(code));
-        }
+    return {
+        .generator = std::move(generator),
+        .converters = std::move(converters),
+        .writer = std::move(writer),
+    };
+  }
 
-        return BuildFilterEnsemble(document);
+  // Run manager
+
+  void ColaRunManager::Run(int n) const {
+    for (auto k = 0; k < n; ++k) {
+      auto event = (*(filterEnsemble_.generator))();
+      for (const auto& converter : filterEnsemble_.converters) {
+        event = std::move(event) | converter;
+      }
+      std::move(event) | filterEnsemble_.writer;
+    }
+  }
+
+  // COLA module
+
+  FactoryMap VModule::GetModuleFilters(const std::optional<std::string>& prefix) const {
+    auto factory_map = DoGetModuleFilters();
+    if (prefix.has_value()) {
+      FactoryMap prefix_map;
+      for (auto& [name, factory] : factory_map) {
+        prefix_map[*prefix + "." + name] = std::move(factory);
+      }
+      return prefix_map;
     }
 
-    FilterEnsemble MetaProcessor::BuildFilterEnsemble(const tinyxml2::XMLDocument& document) const {
-        using namespace tinyxml2;
-        std::unique_ptr<VGenerator> generator;
-        std::vector<std::unique_ptr<VConverter>> converters;
-        std::unique_ptr<VWriter> writer;
+    return factory_map;
+  }
 
-        for (const auto* elem = document.RootElement()->FirstChildElement(); elem != nullptr; elem = elem->NextSiblingElement()) { // nolint
-            if (elem->Name() == "generator"sv) {
-                if (generator != nullptr) {
-                    throw std::runtime_error("Found multiple generators");
-                }
-                generator = DynamicPointerCast<VGenerator>(CreateFilterFromNode(elem, generatorMap_));
-                continue;
-            }
-            if (generator == nullptr) {
-                throw std::runtime_error("Exactly one generator must be described first");
-            }
-            if (writer != nullptr) {
-                throw std::runtime_error("Exactly one writer must be described last");
-            }
+  static const std::string function_name = "LoadCOLAModule";
+  static const std::string env_dir_variable = "COLA_DIR";
+  using LoadModuleFunction = decltype(LoadCOLAModule);
 
-            if (elem->Name() == "converter"sv) {
-                converters.emplace_back(DynamicPointerCast<VConverter>(CreateFilterFromNode(elem, converterMap_)));
-                continue;
-            }
+  std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,
+                                            const std::optional<std::string>& libDirectory) {
+    auto cola_directory = libDirectory.value_or(
+        std::getenv(env_dir_variable.c_str()) != nullptr ? std::getenv(env_dir_variable.c_str()) : "~/.local/lib");
+    if (cola_directory.size() > 1 && cola_directory.substr(0, 2) == "~/") {
+      cola_directory = std::filesystem::path(std::getenv("HOME")) / cola_directory.substr(2);
+    }
+    for (const auto& cola_entry : std::filesystem::directory_iterator(cola_directory)) {
+      if (!cola_entry.is_directory() || cola_entry.path().filename() != moduleName) {
+        continue;
+      }
 
-            if (elem->Name() == "writer"sv) {
-                writer = DynamicPointerCast<VWriter>(CreateFilterFromNode(elem, writerMap_));
-                continue;
+      for (const auto& entry : std::filesystem::directory_iterator(cola_entry.path())) {
+        if (entry.path().extension() == ".so" || entry.path().extension() == ".dylib") {
+          if (auto* library_handler = dlopen(entry.path().c_str(), RTLD_LAZY); library_handler != nullptr) {
+            if (auto* raw_function_ptr = dlsym(library_handler, function_name.c_str());
+                raw_function_ptr != nullptr) {
+              auto* function_ptr = reinterpret_cast<LoadModuleFunction*>(raw_function_ptr);
+              return std::unique_ptr<cola::VModule>(function_ptr());
             }
 
-            throw std::runtime_error(std::string("Unknown node: ") + elem->Name());
+            throw std::runtime_error("Failed to find " + function_name + " function from: " + entry.path().string());
+          }
+
+          throw std::runtime_error("Failed to load module: " + entry.path().string());
         }
-
-        if (generator == nullptr) {
-            throw std::runtime_error("No generator found");
-        }
-
-        if (writer == nullptr) {
-            throw std::runtime_error("No writer found");
-        }
-
-        return {
-            .generator = std::move(generator),
-            .converters = std::move(converters),
-            .writer = std::move(writer),
-        };
+      }
     }
 
-    // Run manager
+    throw std::runtime_error("Failed to find module: " + moduleName + " in: " + cola_directory);
+  }
 
-    void ColaRunManager::Run(int n) const {
-        for (auto k = 0; k < n; ++k) {
-            auto event = (*(filterEnsemble_.generator))();
-            for (const auto& converter : filterEnsemble_.converters) {
-                event = std::move(event) | converter;
-            }
-            std::move(event) | filterEnsemble_.writer;
-        }
-    }
-
-    // COLA module
-
-    FactoryMap VModule::GetModuleFilters(const std::optional<std::string>& prefix) const {
-        auto factoryMap = DoGetModuleFilters();
-        if (prefix.has_value()) {
-            FactoryMap prefixMap;
-            for (auto& [name, factory] : factoryMap) {
-                prefixMap[*prefix + "." + name] = std::move(factory);
-            }
-            return prefixMap;
-        }
-
-        return factoryMap;
-    }
-
-    static const std::string FUNCTION_NAME = "LoadCOLAModule";
-    static const std::string ENV_DIR_VARIABLE = "COLA_DIR";
-    using LoadModuleFunction = decltype(LoadCOLAModule);
-
-    std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,
-                                              const std::optional<std::string>& libDirectory) {
-        auto colaDirectory = libDirectory.value_or(
-            std::getenv(ENV_DIR_VARIABLE.c_str()) != nullptr ? std::getenv(ENV_DIR_VARIABLE.c_str()) : "~/.local/lib");
-        if (colaDirectory.size() > 1 && colaDirectory.substr(0, 2) == "~/") {
-            colaDirectory = std::filesystem::path(std::getenv("HOME")) / colaDirectory.substr(2);
-        }
-        for (const auto& colaEntry : std::filesystem::directory_iterator(colaDirectory)) {
-            if (!colaEntry.is_directory() || colaEntry.path().filename() != moduleName) {
-                continue;
-            }
-
-            for (const auto& entry : std::filesystem::directory_iterator(colaEntry.path())) {
-                if (entry.path().extension() == ".so" || entry.path().extension() == ".dylib") {
-                    if (auto* libraryHandler = dlopen(entry.path().c_str(), RTLD_LAZY); libraryHandler != nullptr) {
-                        if (auto* rawFunctionPtr = dlsym(libraryHandler, FUNCTION_NAME.c_str()); rawFunctionPtr != nullptr) { // nolint
-                            auto* functionPtr = (LoadModuleFunction*)rawFunctionPtr;
-                            return std::unique_ptr<cola::VModule>(functionPtr());
-                        }
-
-                        throw std::runtime_error("Failed to find " + FUNCTION_NAME +
-                                                 " function from: " + entry.path().string());
-                    }
-
-                    throw std::runtime_error("Failed to load module: " + entry.path().string());
-                }
-            }
-        }
-
-        throw std::runtime_error("Failed to find module: " + moduleName + " in: " + colaDirectory);
-    }
-
-} // namespace cola
+}  // namespace cola

--- a/COLA.cc
+++ b/COLA.cc
@@ -21,12 +21,20 @@
 #include "COLA.hh"
 
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
 #include <iostream>
-#include <memory>
+#include <iterator>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 
 #include <tinyxml2.h>
+
+using namespace std::string_view_literals;
 
 namespace {
     static const std::string FILTER_NAME_ATTRIBUTE = "name";
@@ -61,15 +69,19 @@ namespace {
         return factoryMap.at(filterName)->Create(params);
     }
 
-    template <typename Base>
-    std::unique_ptr<Base> DynamicPointerCast(std::unique_ptr<cola::VFilter>&& ptr) {
-        cola::VFilter* raw = ptr.release();
-        auto* derived = dynamic_cast<Base*>(raw);
+    template <typename Target, typename Source>
+    std::unique_ptr<Target> DynamicPointerCast(std::unique_ptr<Source>&& ptr) {
+        Source* raw = ptr.release();
+        auto* derived = dynamic_cast<Target*>(raw);
         if (derived == nullptr) {
             delete raw;
-            throw std::runtime_error("DynamicPointerCast: filter type mismatch");
+            throw std::runtime_error("DynamicPointerCast: type mismatch");
         }
-        return std::unique_ptr<Base>(derived);
+        return std::unique_ptr<Target>(derived);
+    }
+
+    std::string ReadAll(std::istream& is) {
+        return std::string(std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>());
     }
 } // namespace
 
@@ -77,25 +89,25 @@ namespace cola {
 
     // converters
 
-    AZ PdgToAz(int pdgCode) {
+    AZ PdgToAZ(int pdgCode) {
         switch (pdgCode) {
-        case 2112:
-            return {1, 0};
-        case 2212:
-            return {1, 1};
-        default: {
-            AZ data = {0, 0};
-            pdgCode /= 10;
-            for (int i = 0; i < 3; i++) {
-                data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+            case 2112:
+                return {1, 0};
+            case 2212:
+                return {1, 1};
+            default: {
+                AZ data = {0, 0};
                 pdgCode /= 10;
+                for (int i = 0; i < 3; i++) {
+                    data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+                    pdgCode /= 10;
+                }
+                for (int i = 0; i < 3; i++) {
+                    data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+                    pdgCode /= 10;
+                }
+                return data;
             }
-            for (int i = 0; i < 3; i++) {
-                data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
-                pdgCode /= 10;
-            }
-            return data;
-        }
         }
     }
 
@@ -109,8 +121,8 @@ namespace cola {
         return 1000000000 + data.first * 10 + data.second * 10000;
     }
 
-    AZ Particle::GetAz() const {
-        return PdgToAz(pdgCode);
+    AZ Particle::GetAZ() const {
+        return PdgToAZ(pdgCode);
     }
 
     // operators
@@ -158,65 +170,81 @@ namespace cola {
     FilterEnsemble MetaProcessor::Parse(const std::string& fName) const {
         using namespace tinyxml2;
         std::cout << "Parsing XML file:" << '\n';
-        XMLDocument file;
+        tinyxml2::XMLDocument file;
         auto code = file.LoadFile(fName.c_str());
-        if (code != XML_SUCCESS) {
+        if (code != tinyxml2::XML_SUCCESS) {
             throw std::runtime_error("ERROR in MetaProcessor: Couldn't open file `" + fName +
                                      "`.\nError code (tinyxml2): " + std::to_string(code));
         }
 
-        FilterEnsemble ensemble;
-        const tinyxml2::XMLNode* root = file.RootElement();
-        if (root == nullptr) {
-            throw std::runtime_error("ERROR in MetaProcessor: Empty XML document");
+        return BuildFilterEnsemble(file);
+    }
+
+    FilterEnsemble MetaProcessor::Parse(std::istream& contents) const {
+        tinyxml2::XMLDocument document;
+        auto str = ReadAll(contents);
+        std::cerr << str << '\n';
+        auto code = document.Parse(str.c_str());
+        if (code != tinyxml2::XML_SUCCESS) {
+            throw std::runtime_error("ERROR in MetaProcessor: bad XML file.\nError code (tinyxml2): " +
+                                     std::to_string(code));
         }
 
-        for (const tinyxml2::XMLNode* node = root->FirstChild(); node != nullptr; node = node->NextSibling()) {
-            const auto* elem = node->ToElement();
-            if (elem == nullptr) {
-                continue;
-            }
+        return BuildFilterEnsemble(document);
+    }
 
-            if (ensemble.writer != nullptr) {
+    FilterEnsemble MetaProcessor::BuildFilterEnsemble(const tinyxml2::XMLDocument& document) const {
+        using namespace tinyxml2;
+        std::unique_ptr<VGenerator> generator;
+        std::vector<std::unique_ptr<VConverter>> converters;
+        std::unique_ptr<VWriter> writer;
+
+        const tinyxml2::XMLElement* root = document.RootElement();
+        if (root == nullptr) {
+            throw std::runtime_error("Empty XML document");
+        }
+
+        for (const auto* elem = root->FirstChildElement(); elem != nullptr; elem = elem->NextSiblingElement()) {
+            if (writer != nullptr) {
                 throw std::runtime_error("Unexpected element after writer");
             }
 
-            const std::string tag(elem->Name());
-
-            if (tag == "generator") {
-                if (ensemble.generator != nullptr) {
+            if (elem->Name() == "generator"sv) {
+                if (generator != nullptr) {
                     throw std::runtime_error("Found multiple generators");
                 }
-                ensemble.generator =
-                    DynamicPointerCast<VGenerator>(CreateFilterFromNode(elem, generatorMap_));
+                generator = DynamicPointerCast<VGenerator>(CreateFilterFromNode(elem, generatorMap_));
                 continue;
             }
-
-            if (ensemble.generator == nullptr) {
+            if (generator == nullptr) {
                 throw std::runtime_error("Exactly one generator must be described first");
             }
 
-            if (tag == "converter") {
-                ensemble.converters.emplace_back(
-                    DynamicPointerCast<VConverter>(CreateFilterFromNode(elem, converterMap_)));
+            if (elem->Name() == "converter"sv) {
+                converters.emplace_back(DynamicPointerCast<VConverter>(CreateFilterFromNode(elem, converterMap_)));
                 continue;
             }
 
-            if (tag == "writer") {
-                ensemble.writer = DynamicPointerCast<VWriter>(CreateFilterFromNode(elem, writerMap_));
+            if (elem->Name() == "writer"sv) {
+                writer = DynamicPointerCast<VWriter>(CreateFilterFromNode(elem, writerMap_));
                 continue;
             }
 
-            throw std::runtime_error("Unknown node: " + tag);
+            throw std::runtime_error(std::string("Unknown node: ") + elem->Name());
         }
 
-        if (ensemble.generator == nullptr) {
-            throw std::runtime_error("Missing generator element");
-        }
-        if (ensemble.writer == nullptr) {
-            throw std::runtime_error("Missing writer element");
+        if (generator == nullptr) {
+            throw std::runtime_error("No generator found");
         }
 
+        if (writer == nullptr) {
+            throw std::runtime_error("No writer found");
+        }
+
+        FilterEnsemble ensemble;
+        ensemble.generator = std::move(generator);
+        ensemble.converters = std::move(converters);
+        ensemble.writer = std::move(writer);
         return ensemble;
     }
 
@@ -230,6 +258,57 @@ namespace cola {
             }
             std::move(event) | filterEnsemble_.writer;
         }
+    }
+
+    // COLA module
+
+    FactoryMap VModule::GetModuleFilters(const std::optional<std::string>& prefix) const {
+        auto factoryMap = DoGetModuleFilters();
+        if (prefix.has_value()) {
+            FactoryMap prefixMap;
+            for (auto& [name, factory] : factoryMap) {
+                prefixMap[*prefix + "." + name] = std::move(factory);
+            }
+            return prefixMap;
+        }
+
+        return factoryMap;
+    }
+
+    static const std::string FUNCTION_NAME = "LoadCOLAModule";
+    static const std::string ENV_DIR_VARIABLE = "COLA_DIR";
+    using LoadModuleFunction = decltype(LoadCOLAModule);
+
+    std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,
+                                              const std::optional<std::string>& libDirectory) {
+        auto colaDirectory = libDirectory.value_or(
+            std::getenv(ENV_DIR_VARIABLE.c_str()) != nullptr ? std::getenv(ENV_DIR_VARIABLE.c_str()) : "~/.local/lib");
+        if (colaDirectory.size() > 1 && colaDirectory.substr(0, 2) == "~/") {
+            colaDirectory = std::filesystem::path(std::getenv("HOME")) / colaDirectory.substr(2);
+        }
+        for (const auto& colaEntry : std::filesystem::directory_iterator(colaDirectory)) {
+            if (!colaEntry.is_directory() || colaEntry.path().filename() != moduleName) {
+                continue;
+            }
+
+            for (const auto& entry : std::filesystem::directory_iterator(colaEntry.path())) {
+                if (entry.path().extension() == ".so" || entry.path().extension() == ".dylib") {
+                    if (auto* libraryHandler = dlopen(entry.path().c_str(), RTLD_LAZY); libraryHandler != nullptr) {
+                        if (auto* rawFunctionPtr = dlsym(libraryHandler, FUNCTION_NAME.c_str()); rawFunctionPtr != nullptr) { // nolint
+                            auto* functionPtr = (LoadModuleFunction*)rawFunctionPtr;
+                            return std::unique_ptr<cola::VModule>(functionPtr());
+                        }
+
+                        throw std::runtime_error("Failed to find " + FUNCTION_NAME +
+                                                 " function from: " + entry.path().string());
+                    }
+
+                    throw std::runtime_error("Failed to load module: " + entry.path().string());
+                }
+            }
+        }
+
+        throw std::runtime_error("Failed to find module: " + moduleName + " in: " + colaDirectory);
     }
 
 } // namespace cola

--- a/COLA.cc
+++ b/COLA.cc
@@ -147,18 +147,19 @@ namespace cola {
         }
     }
 
-    void MetaProcessor::Register(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+    void MetaProcessor::Register(std::unique_ptr<VFactory>&& factory, const std::optional<std::string>& name) {
+        auto filterName = name.value_or(factory->GetFilterName());
         switch (factory->GetFilterType()) {
             case FilterType::GENERATOR: {
-                RegisterGenerator(std::move(factory), name);
+                RegisterGenerator(std::move(factory), filterName);
                 break;
             }
             case FilterType::CONVERTER: {
-                RegisterConverter(std::move(factory), name);
+                RegisterConverter(std::move(factory), filterName);
                 break;
             }
             case FilterType::WRITER: {
-                RegisterWriter(std::move(factory), name);
+                RegisterWriter(std::move(factory), filterName);
                 break;
             }
             default: {

--- a/COLA.cc
+++ b/COLA.cc
@@ -23,8 +23,6 @@
 #include <dlfcn.h>
 #include <tinyxml2.h>
 
-#include <cmath>
-#include <cstdint>
 #include <filesystem>
 #include <iostream>
 #include <iterator>
@@ -82,38 +80,6 @@ namespace {
 namespace cola {
 
   // converters
-
-  AZ PdgToAZ(int pdgCode) {
-    switch (pdgCode) {
-      case 2112:
-        return {1, 0};
-      case 2212:
-        return {1, 1};
-      default: {
-        AZ data = {0, 0};
-        pdgCode /= 10;
-        for (int i = 0; i < 3; i++) {
-          data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
-          pdgCode /= 10;
-        }
-        for (int i = 0; i < 3; i++) {
-          data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
-          pdgCode /= 10;
-        }
-        return data;
-      }
-    }
-  }
-
-  int AZToPdg(AZ data) {
-    if (data.first == 1 && data.second == 0) {
-      return 2112;
-    }
-    if (data.first == 1 && data.second == 1) {
-      return 2212;
-    }
-    return 1000000000 + data.first * 10 + data.second * 10000;
-  }
 
   AZ Particle::GetAZ() const { return PdgToAZ(pdgCode); }
 

--- a/COLA.cc
+++ b/COLA.cc
@@ -22,7 +22,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <dlfcn.h>
 #include <filesystem>
 #include <iostream>
@@ -30,7 +29,6 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 #include <tinyxml2.h>
 
@@ -71,13 +69,9 @@ namespace {
 
     template <typename Target, typename Source>
     std::unique_ptr<Target> DynamicPointerCast(std::unique_ptr<Source>&& ptr) {
-        Source* raw = ptr.release();
-        auto* derived = dynamic_cast<Target*>(raw);
-        if (derived == nullptr) {
-            delete raw;
-            throw std::runtime_error("DynamicPointerCast: type mismatch");
-        }
-        return std::unique_ptr<Target>(derived);
+        auto result = std::unique_ptr<Target>(&dynamic_cast<Target&>(*ptr.get()));
+        ptr.release();
+        return result;
     }
 
     std::string ReadAll(std::istream& is) {
@@ -184,7 +178,6 @@ namespace cola {
     FilterEnsemble MetaProcessor::Parse(std::istream& contents) const {
         tinyxml2::XMLDocument document;
         auto str = ReadAll(contents);
-        std::cerr << str << '\n';
         auto code = document.Parse(str.c_str());
         if (code != tinyxml2::XML_SUCCESS) {
             throw std::runtime_error("ERROR in MetaProcessor: bad XML file.\nError code (tinyxml2): " +
@@ -200,16 +193,7 @@ namespace cola {
         std::vector<std::unique_ptr<VConverter>> converters;
         std::unique_ptr<VWriter> writer;
 
-        const tinyxml2::XMLElement* root = document.RootElement();
-        if (root == nullptr) {
-            throw std::runtime_error("Empty XML document");
-        }
-
-        for (const auto* elem = root->FirstChildElement(); elem != nullptr; elem = elem->NextSiblingElement()) {
-            if (writer != nullptr) {
-                throw std::runtime_error("Unexpected element after writer");
-            }
-
+        for (const auto* elem = document.RootElement()->FirstChildElement(); elem != nullptr; elem = elem->NextSiblingElement()) { // nolint
             if (elem->Name() == "generator"sv) {
                 if (generator != nullptr) {
                     throw std::runtime_error("Found multiple generators");
@@ -219,6 +203,9 @@ namespace cola {
             }
             if (generator == nullptr) {
                 throw std::runtime_error("Exactly one generator must be described first");
+            }
+            if (writer != nullptr) {
+                throw std::runtime_error("Exactly one writer must be described last");
             }
 
             if (elem->Name() == "converter"sv) {
@@ -242,11 +229,11 @@ namespace cola {
             throw std::runtime_error("No writer found");
         }
 
-        FilterEnsemble ensemble;
-        ensemble.generator = std::move(generator);
-        ensemble.converters = std::move(converters);
-        ensemble.writer = std::move(writer);
-        return ensemble;
+        return {
+            .generator = std::move(generator),
+            .converters = std::move(converters),
+            .writer = std::move(writer),
+        };
     }
 
     // Run manager

--- a/COLA.hh
+++ b/COLA.hh
@@ -21,11 +21,16 @@
 #ifndef COLA_COLA_HH
 #define COLA_COLA_HH
 
-#include <unordered_map>
 #include <memory>
+#include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "LorentzVector.hh"
+
+namespace tinyxml2 {
+    class XMLDocument;
+} // namespace tinyxml2
 
 namespace cola {
     using LorentzVector = LorentzVectorImpl<double>;
@@ -39,7 +44,7 @@ namespace cola {
      *  @param pdgCode PDG code of the ion.
      *  @return AZ of the ion.
      */
-    AZ PdgToAz(int pdgCode);
+    AZ PdgToAZ(int pdgCode);
 
     /** AZ to PDG code convverter.
      *  @param data AZ of the ion.
@@ -75,7 +80,7 @@ namespace cola {
      *  A structure representing data about a single particle
      */
     struct Particle {
-        AZ GetAz() const;
+        AZ GetAZ() const;
 
         LorentzVector position; /**< Position <t, x, y, z> vector. */
 
@@ -252,24 +257,44 @@ namespace cola {
 
     using FactoryMap = std::unordered_map<std::string, std::unique_ptr<VFactory>>;
 
-    class VGeneratorFactory: public VFactory {
+    class VGeneratorFactory : public VFactory {
       public:
         FilterType GetFilterType() const final {
-          return FilterType::GENERATOR;
+            return FilterType::GENERATOR;
         }
     };
 
-    class VConverterFactory: public VFactory {
+    class VConverterFactory : public VFactory {
       public:
         FilterType GetFilterType() const final {
-          return FilterType::CONVERTER;
+            return FilterType::CONVERTER;
         }
     };
 
-    class VWriterFactory: public VFactory {
+    class VWriterFactory : public VFactory {
       public:
         FilterType GetFilterType() const final {
-          return FilterType::WRITER;
+            return FilterType::WRITER;
+        }
+    };
+
+    template <typename Filter>
+    class GenericFactory : public VFactory {
+      public:
+        std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& /* metaData */) override {
+            return std::make_unique<Filter>();
+        }
+
+        FilterType GetFilterType() const final {
+            if constexpr (std::is_base_of_v<VGenerator, Filter>) {
+                return FilterType::GENERATOR;
+            } else if constexpr (std::is_base_of_v<VConverter, Filter>) {
+                return FilterType::CONVERTER;
+            } else if constexpr (std::is_base_of_v<VWriter, Filter>) {
+                return FilterType::WRITER;
+            } else {
+                static_assert(true, "unhandled 'FilterType' value");
+            }
         }
     };
 
@@ -329,10 +354,18 @@ namespace cola {
          */
         FilterEnsemble Parse(const std::string& fName) const;
 
+        /** A method to parse a XML-file to set up a configured FilterEnsemble.
+         *  @param contents configuration XML-file contents
+         *  @return A configured FilterEnsemble.
+         */
+        FilterEnsemble Parse(std::istream& contents) const;
+
       private:
         FactoryMap generatorMap_;
         FactoryMap converterMap_;
         FactoryMap writerMap_;
+
+        FilterEnsemble BuildFilterEnsemble(const tinyxml2::XMLDocument& document) const;
 
         void RegisterGenerator(std::unique_ptr<VFactory>&& factory, const std::string& name) {
             generatorMap_.emplace(name, std::move(factory));
@@ -366,6 +399,28 @@ namespace cola {
       private:
         FilterEnsemble filterEnsemble_;
     };
+
+    class VModule {
+      public:
+        VModule() = default;
+
+        FactoryMap GetModuleFilters(const std::optional<std::string>& prefix = std::nullopt) const;
+
+        virtual ~VModule() = default;
+
+      private:
+        virtual FactoryMap DoGetModuleFilters() const = 0;
+    };
+
+    std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,
+                                              const std::optional<std::string>& libDirectory = std::nullopt);
 } // namespace cola
+
+extern "C" {
+/** Loads COLA module in runtime, shouldn't be used directly
+ * @return A cola::VModule class wrapping specific COLA module
+ */
+cola::VModule* LoadCOLAModule();
+}
 
 #endif // COLA_COLA_HH

--- a/COLA.hh
+++ b/COLA.hh
@@ -334,7 +334,7 @@ namespace cola {
         factories[factory->GetFilterName()] = std::move(factory);
       }
 
-      if (sizeof...(Types) > 0) {
+      if constexpr (sizeof...(Types) > 0) {
         AddFilter<Types...>(factories);
       }
     }

--- a/COLA.hh
+++ b/COLA.hh
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -253,6 +254,8 @@ namespace cola {
         virtual std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& metaData) = 0;
 
         virtual FilterType GetFilterType() const = 0;
+
+        virtual const std::string& GetFilterName() const = 0;
     };
 
     using FactoryMap = std::unordered_map<std::string, std::unique_ptr<VFactory>>;
@@ -280,9 +283,29 @@ namespace cola {
 
     template <typename Filter>
     class GenericFactory : public VFactory {
+      private:
+        template<typename, typename = void>
+        struct HasName : std::false_type {};
+        
+        template<typename T>
+        struct HasName<T, std::void_t<decltype(T::NAME)>> : std::true_type {};
+
+        template<typename T>
+        static constexpr bool HAS_NAME = HasName<T>::value;
+
       public:
+        GenericFactory() {
+            static_assert(std::is_base_of_v<VFilter, Filter>, "Filter template must inherit cola::VFilter");
+            static_assert(HAS_NAME<Filter>, "Filter class must have NAME class variable");
+            static_assert(std::is_same_v<std::remove_reference_t<std::remove_cv_t<decltype(Filter::NAME)>>, std::string>, "NAME variable must be a string");
+        }
+
         std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& /* metaData */) override {
             return std::make_unique<Filter>();
+        }
+
+        const std::string& GetFilterName() const final {
+            return Filter::NAME;
         }
 
         FilterType GetFilterType() const final {
@@ -340,7 +363,7 @@ namespace cola {
          * @param factory A rvalue-reference to the Filter factory pointer
          * @param name The name of the Filter.
          */
-        void Register(std::unique_ptr<VFactory>&& factory, const std::string& name);
+        void Register(std::unique_ptr<VFactory>&& factory, const std::optional<std::string>& name = std::nullopt);
 
         /** A method to parse a XML-file to set up a configured FilterEnsemble.
          *  This method opens an XML-file @param fName to get the information to set up the model.
@@ -410,6 +433,30 @@ namespace cola {
 
       private:
         virtual FactoryMap DoGetModuleFilters() const = 0;
+    };
+
+    template <typename... FilterTypes>
+    class GenericModule : public VModule {
+      private:
+        template <typename HeadType, typename... Types>
+        static void AddFilter(FactoryMap& factories) {
+            static_assert(std::is_base_of_v<VFactory, HeadType>, "all types must be Factories");
+
+            {
+                auto factory = std::make_unique<HeadType>();
+                factories[factory->GetFilterName()] = std::move(factory);
+            }
+
+            if (sizeof...(Types) > 0) {
+                AddFilter<Types...>(factories);
+            }
+        }
+
+        FactoryMap DoGetModuleFilters() const override {
+            FactoryMap factories;
+            AddFilter<FilterTypes...>(factories);
+            return factories;
+        }
     };
 
     std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,

--- a/COLA.hh
+++ b/COLA.hh
@@ -21,447 +21,429 @@
 #ifndef COLA_COLA_HH
 #define COLA_COLA_HH
 
+#include "LorentzVector.hh"
+
 #include <memory>
 #include <optional>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
 
-#include "LorentzVector.hh"
-
 namespace tinyxml2 {
-    class XMLDocument;
-} // namespace tinyxml2
+  class XMLDocument;
+}  // namespace tinyxml2
 
 namespace cola {
-    using LorentzVector = LorentzVectorImpl<double>;
+  using LorentzVector = LorentzVectorImpl<double>;
 
-    /** A typedef representing mass and charge of a nucleon.
+  /** A typedef representing mass and charge of a nucleon.
+   */
+  using AZ = std::pair<uint16_t, uint16_t>;
+
+  /** PDG code to AZ converter.
+   *  **WARNING:** this function is intended to process heavy ions PDG codes.
+   *  @param pdgCode PDG code of the ion.
+   *  @return AZ of the ion.
+   */
+  AZ PdgToAZ(int pdgCode);
+
+  /** AZ to PDG code convverter.
+   *  @param data AZ of the ion.
+   *  @return PDG code of the ion
+   */
+  int AZToPdg(AZ data);
+
+  /** \defgroup Data Data Classes and supporting methods.
+   * @{
+   */
+
+  /** Particle class by generator output.
+   *  This enum represents various outcomes of a generator event for every particle.
+   */
+  enum class ParticleClass : char {
+    kProduced,    /**< A particle that was not present in the starting nuclei. */
+    kElasticA,    /**< A particle that was present in the projectile nucleus and has experienced only elastic
+                   * interactions.
+                   */
+    kElasticB,    /**< A particle that was present in the target nucleus and has experienced only elastic interactions.
+                   */
+    kNonelasticA, /**< A particle that was present in the projectile nucleus and has experienced at least one
+                    non-elastic interaction. */
+    kNonelasticB, /**< A particle that was present in the target nucleus and has experienced at least one
+                    non-elastic interaction. */
+    kSpectatorA,  /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
+                   */
+    kSpectatorB   /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
+                   */
+  };
+
+  /** Particle data.
+   *  A structure representing data about a single particle
+   */
+  struct Particle {
+    AZ GetAZ() const;
+
+    LorentzVector position; /**< Position <t, x, y, z> vector. */
+
+    LorentzVector momentum; /**< Momentum <e, x, y, z> vector. */
+
+    int pdgCode;          /**< PDG code of the particle. */
+    ParticleClass pClass; /**< Data about particle origin. See ParticleClass for more info.*/
+  };
+
+  /**
+   * Convenient typedef for Particle vector.
+   */
+  using EventParticles = std::vector<Particle>;
+
+  /** Initial state data.
+   *  This structure contains data about initial state of any given event.
+   */
+  struct EventIniState {
+    int pdgCodeA; /**< PDF code of the projectile. */
+    int pdgCodeB; /**< PDF code of the target. */
+
+    double pZA;    /** Axial momentum of the projectile */
+    double pZB;    /** Axial momentum of the target */
+    double energy; /** Incidental energy of the event. Depending on pZB being zero, this is either \f$E/A\f$ of
+                      target or \f$\sqrt{s_{NN}}\f$. */
+
+    float sectNN; /** Nucleon-Nucleon cross section from generator. */
+    float b;      /** Impact parameter of the event. */
+
+    int nColl;   /** Diagnostic. Total number of collisions. */
+    int nCollPP; /** Diagnostic. Number of proton-proton. */
+    int nCollPN; /** Diagnostic. Number of proton-neutron collisions. */
+    int nCollNN; /** Diagnostic. Number of neutron-neutron collisions. */
+    int nPart;   /** Diagnostic. Total number of participants. */
+    int nPartA;  /** Diagnostic. Number of participants from the projectile nucleus. */
+    int nPartB;  /** Diagnostic. Number of participants from the target nucleus. */
+
+    float phiRotA;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the projectile nucleon. */
+    float thetaRotA; /** Diagnostic. Polar angle \f&\Theta\f$ of rotation of the projectile nucleon. */
+    float phiRotB;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the target nucleon. */
+    float thetaRotB; /** Diagnostic. Polar angle \f$\Theta\f$ of rotation of the target nucleon. */
+
+    EventParticles iniStateParticles; /** The array of all Particles just before the event. */
+  };
+
+  /** A structure combining EventIniState and EventParticles of the event.
+   */
+  struct EventData {
+    EventIniState iniState;
+    EventParticles particles;
+  };
+
+  /** @}
+   * \defgroup Interface Pure abstract classes used for dependency injection.
+   * @{
+   */
+
+  /** A common abstract parent class representing any model in the pipeline.
+   *  A single model in the COLA-driven pipeline is named a Filter.
+   */
+  class VFilter {
+   public:
+    VFilter() = default;
+    VFilter(const VFilter&) = delete;
+    VFilter(VFilter&&) = delete;
+    VFilter& operator=(const VFilter&) = delete;
+    VFilter& operator=(VFilter&&) = delete;
+    virtual ~VFilter() = 0;
+  };
+
+  inline VFilter::~VFilter() = default;
+
+  /** Generator abstract class.
+   *  This is a generator interface. Generators are the first step of the MC simulation: they take data from existing
+   *  files or encapsulate nucleus-nucleus collision generators.
+   */
+  class VGenerator : public VFilter {
+   public:
+    VGenerator() = default;
+    VGenerator(const VGenerator&) = delete;
+    VGenerator(VGenerator&&) = delete;
+    VGenerator& operator=(const VGenerator&) = delete;
+    VGenerator& operator=(VGenerator&&) = delete;
+    ~VGenerator() override = 0;
+
+    /** A method to request one event from the generator.
+     *  Users are supposed to override this method to provide a single event from the generator model.
+     *  @return A pointer to the EventData of the produced event.
      */
-    using AZ = std::pair<uint16_t, uint16_t>;
+    virtual std::unique_ptr<EventData> operator()() = 0;
+  };
 
-    /** PDG code to AZ converter.
-     *  **WARNING:** this function is intended to process heavy ions PDG codes.
-     *  @param pdgCode PDG code of the ion.
-     *  @return AZ of the ion.
+  inline VGenerator::~VGenerator() = default;
+
+  /** Converter abstract class.
+   *  This is a converter interface. It is inherited by all filters that are in the middle of MC simulation.
+   *  Converters are intended to transform data from previous steps.
+   */
+  class VConverter : public VFilter {
+   public:
+    VConverter() = default;
+    VConverter(const VConverter&) = delete;
+    VConverter(VConverter&&) = delete;
+    VConverter& operator=(const VConverter&) = delete;
+    VConverter& operator=(VConverter&&) = delete;
+    ~VConverter() override = 0;
+
+    /** A method to process one event by the converter model.
+     *  Users are supposed to override this method to process a single event by the converter model.
+     *  @param data A pointer to the EventData to be processed.
+     *  @return A pointer to the EventData of the processed event.
      */
-    AZ PdgToAZ(int pdgCode);
+    virtual std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) = 0;
+  };
 
-    /** AZ to PDG code convverter.
-     *  @param data AZ of the ion.
-     *  @return PDG code of the ion
+  inline VConverter::~VConverter() = default;
+
+  /** Writer abstract class.
+   *  This is a writer interface. Writers are what the name suggests - they implement writing results into different
+   *  data formats. Note, that it isn't necessary to *only* write events to memory with this class. If you need to
+   *  process data in a way that the EventData is incompatible with the output (for example, you want to model a
+   *  detector response to the generated event) you can encapsulate these calculations in a writer class.
+   */
+  class VWriter : public VFilter {
+   public:
+    VWriter() = default;
+    VWriter(const VWriter&) = delete;
+    VWriter(VWriter&&) = delete;
+    VWriter& operator=(const VWriter&) = delete;
+    VWriter& operator=(VWriter&&) = delete;
+    ~VWriter() override = 0;
+
+    /** A method to save one event by the writer.
+     *  Users are supposed to override this method to save a single event. Note, that the implementation is left
+     *  to the user: you can save events to buffer with this method and write them to the filesystem in batches if
+     *  you please so.
+     *  @param data A pointer to the EventData to be saved.
      */
-    int AZToPdg(AZ data);
+    virtual void operator()(std::unique_ptr<EventData>&& data) = 0;
+  };
 
-    /** \defgroup Data Data Classes and supporting methods.
-     * @{
+  inline VWriter::~VWriter() = default;
+
+  /** An enum for marking Filter types.
+   */
+  enum class FilterType : char { kGenerator, kConverter, kWriter };
+
+  /** Factory abstract class.
+   * This is a factory interface. It generates a Filter with its VFactory::create method. DI in COLA works via using
+   * the factory classes, which are registered in a MetaProcessor instance.
+   */
+  class VFactory {
+   public:
+    VFactory() = default;
+    VFactory(const VFactory&) = delete;
+    VFactory(VFactory&&) = delete;
+    VFactory& operator=(const VFactory&) = delete;
+    VFactory& operator=(VFactory&&) = delete;
+    virtual ~VFactory() = default;
+
+    /** The method for constructing filters.
+     *  This method is intended to be called in MetaProcessor with key-value pairs obtained from a XML-file.
+     *  @param metaData A dictionary with key-value pairs needed for configuring a model.
+     *  @return A configured class that is a VFilter child.
      */
+    virtual std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& metaData) = 0;
 
-    /** Particle class by generator output.
-     *  This enum represents various outcomes of a generator event for every particle.
+    virtual FilterType GetFilterType() const = 0;
+
+    virtual const std::string& GetFilterName() const = 0;
+  };
+
+  using FactoryMap = std::unordered_map<std::string, std::unique_ptr<VFactory>>;
+
+  class VGeneratorFactory : public VFactory {
+   public:
+    FilterType GetFilterType() const final { return FilterType::kGenerator; }
+  };
+
+  class VConverterFactory : public VFactory {
+   public:
+    FilterType GetFilterType() const final { return FilterType::kConverter; }
+  };
+
+  class VWriterFactory : public VFactory {
+   public:
+    FilterType GetFilterType() const final { return FilterType::kWriter; }
+  };
+
+  template <typename Filter> class GenericFactory : public VFactory {
+   private:
+    template <typename, typename = void> struct HasName : std::false_type {};
+
+    template <typename T> struct HasName<T, std::void_t<decltype(T::kName)>> : std::true_type {};
+
+    template <typename T> static constexpr bool kHasName = HasName<T>::value;
+
+   public:
+    GenericFactory() {
+      static_assert(std::is_base_of_v<VFilter, Filter>, "Filter template must inherit cola::VFilter");
+      static_assert(kHasName<Filter>, "Filter class must have kName class variable");
+      static_assert(std::is_same_v<std::remove_reference_t<std::remove_cv_t<decltype(Filter::kName)>>, std::string>,
+                    "kName variable must be a string");
+    }
+
+    std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& /* metaData */) override {
+      return std::make_unique<Filter>();
+    }
+
+    const std::string& GetFilterName() const final { return Filter::kName; }
+
+    FilterType GetFilterType() const final {
+      if constexpr (std::is_base_of_v<VGenerator, Filter>) {
+        return FilterType::kGenerator;
+      } else if constexpr (std::is_base_of_v<VConverter, Filter>) {
+        return FilterType::kConverter;
+      } else if constexpr (std::is_base_of_v<VWriter, Filter>) {
+        return FilterType::kWriter;
+      } else {
+        static_assert(true, "unhandled 'FilterType' value");
+      }
+    }
+  };
+
+  std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& /*generator*/,
+                                       const std::unique_ptr<VConverter>& /*converter*/);
+  std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& /*data*/,
+                                       const std::unique_ptr<VConverter>& /*converter*/);
+  void operator|(std::unique_ptr<EventData>&& /*data*/, const std::unique_ptr<VWriter>& /*writer*/);
+
+  /** @}
+   *  \defgroup Metadata Classes for constructing and running a model.
+   *  @{
+   */
+
+  /** A structure representing the model pipeline.
+   */
+  struct FilterEnsemble {
+    std::unique_ptr<VGenerator> generator;               /**< Event generator. */
+    std::vector<std::unique_ptr<VConverter>> converters; /**< Vector of converters, applied step-by-step. */
+    std::unique_ptr<VWriter> writer;                     /**< Writer to save the results. */
+  };
+
+  /** A class for processing meta information.
+   *  This class stores data about all available Filters and corresponding factory classes and uses it to create the
+   *  pipeline using its MetaProcessor:parse method to read all needed information from an XML-file.
+   */
+  class MetaProcessor {
+   public:
+    /** Default constructor.
      */
-    enum class ParticleClass : char {
-        PRODUCED,  /**< A particle that was not present in the starting nuclei. */
-        ELASTIC_A, /**< A particle that was present in the projectile nucleus and has experienced only elastic
-                    * interactions.
-                    */
-        ELASTIC_B, /**< A particle that was present in the target nucleus and has experienced only elastic interactions.
-                    */
-        NONELASTIC_A, /**< A particle that was present in the projectile nucleus and has experienced at least one
-                        non-elastic interaction. */
-        NONELASTIC_B, /**< A particle that was present in the target nucleus and has experienced at least one
-                        non-elastic interaction. */
-        SPECTATOR_A, /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
-                      */
-        SPECTATOR_B  /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
-                      */
-    };
+    MetaProcessor() = default;
 
-    /** Particle data.
-     *  A structure representing data about a single particle
+    /** Constructor with immediate factories registration.
+     * Note that unique pointers in the dictionary are invalidated.
+     * @param filterMap A dictionary with all relevant information. Note that unique pointers in the dictionary are
+     * invalidated.
      */
-    struct Particle {
-        AZ GetAZ() const;
+    explicit MetaProcessor(FactoryMap&& filterMap);
 
-        LorentzVector position; /**< Position <t, x, y, z> vector. */
+    ~MetaProcessor() = default;
 
-        LorentzVector momentum; /**< Momentum <e, x, y, z> vector. */
-
-        int pdgCode;          /**< PDG code of the particle. */
-        ParticleClass pClass; /**< Data about particle origin. See ParticleClass for more info.*/
-    };
-
-    /**
-     * Convenient typedef for Particle vector.
+    /** A method for registering new Filters.
+     * @param factory A rvalue-reference to the Filter factory pointer
+     * @param name The name of the Filter.
      */
-    using EventParticles = std::vector<Particle>;
+    void Register(std::unique_ptr<VFactory>&& factory, const std::optional<std::string>& name = std::nullopt);
 
-    /** Initial state data.
-     *  This structure contains data about initial state of any given event.
+    /** A method to parse a XML-file to set up a configured FilterEnsemble.
+     *  This method opens an XML-file @param fName to get the information to set up the model.
+     *  Inside the root element should be one <generator> element followed by any number of <converter> elements
+     *  (none is possible) and, finally, a <writer> element. Each element must have "name" attribute followed by
+     *  any number of additional attributes. These attributes are then passed to the corresponding factory's
+     * VFactory::create method as a dictionary with keys being attribute names and values - attribute values. This
+     * method throws an error if a relevant factory isn't found or XML-file is malformed.
+     *  @param fName Name with the configuration XML-file.
+     *  @return A configured FilterEnsemble.
      */
-    struct EventIniState {
-        int pdgCodeA; /**< PDF code of the projectile. */
-        int pdgCodeB; /**< PDF code of the target. */
+    FilterEnsemble Parse(const std::string& fName) const;
 
-        double pZA;    /** Axial momentum of the projectile */
-        double pZB;    /** Axial momentum of the target */
-        double energy; /** Incidental energy of the event. Depending on pZB being zero, this is either \f$E/A\f$ of
-                          target or \f$\sqrt{s_{NN}}\f$. */
-
-        float sectNN; /** Nucleon-Nucleon cross section from generator. */
-        float b;      /** Impact parameter of the event. */
-
-        int nColl;   /** Diagnostic. Total number of collisions. */
-        int nCollPP; /** Diagnostic. Number of proton-proton. */
-        int nCollPN; /** Diagnostic. Number of proton-neutron collisions. */
-        int nCollNN; /** Diagnostic. Number of neutron-neutron collisions. */
-        int nPart;   /** Diagnostic. Total number of participants. */
-        int nPartA;  /** Diagnostic. Number of participants from the projectile nucleus. */
-        int nPartB;  /** Diagnostic. Number of participants from the target nucleus. */
-
-        float phiRotA;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the projectile nucleon. */
-        float thetaRotA; /** Diagnostic. Polar angle \f&\Theta\f$ of rotation of the projectile nucleon. */
-        float phiRotB;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the target nucleon. */
-        float thetaRotB; /** Diagnostic. Polar angle \f$\Theta\f$ of rotation of the target nucleon. */
-
-        EventParticles iniStateParticles; /** The array of all Particles just before the event. */
-    };
-
-    /** A structure combining EventIniState and EventParticles of the event.
+    /** A method to parse a XML-file to set up a configured FilterEnsemble.
+     *  @param contents configuration XML-file contents
+     *  @return A configured FilterEnsemble.
      */
-    struct EventData {
-        EventIniState iniState;
-        EventParticles particles;
-    };
+    FilterEnsemble Parse(std::istream& contents) const;
 
-    /** @}
-     * \defgroup Interface Pure abstract classes used for dependency injection.
-     * @{
+   private:
+    FactoryMap generatorMap_;
+    FactoryMap converterMap_;
+    FactoryMap writerMap_;
+
+    FilterEnsemble BuildFilterEnsemble(const tinyxml2::XMLDocument& document) const;
+
+    void RegisterGenerator(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+      generatorMap_.emplace(name, std::move(factory));
+    }
+    void RegisterConverter(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+      converterMap_.emplace(name, std::move(factory));
+    }
+    void RegisterWriter(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+      writerMap_.emplace(name, std::move(factory));
+    }
+  };
+
+  /** Manager class.
+   * Currently more of a boilerplate, but potentially useful to incorporate parallel computing.
+   */
+  class ColaRunManager {
+   public:
+    /** A constructor that moves the configured FilterEnsemble into the manager.
+     * @param ensemble Configured model.
      */
+    explicit ColaRunManager(FilterEnsemble&& ensemble) : filterEnsemble_(std::move(ensemble)) {}
 
-    /** A common abstract parent class representing any model in the pipeline.
-     *  A single model in the COLA-driven pipeline is named a Filter.
+    ~ColaRunManager() = default;
+
+    /** A method to run the resulting model @param n times.
+     * @param n Number of runs.
      */
-    class VFilter {
-      public:
-        VFilter() = default;
-        VFilter(const VFilter&) = delete;
-        VFilter(VFilter&&) = delete;
-        VFilter& operator=(const VFilter&) = delete;
-        VFilter& operator=(VFilter&&) = delete;
-        virtual ~VFilter() = 0;
-    };
+    void Run(int n = 1) const;
 
-    inline VFilter::~VFilter() = default;
+   private:
+    FilterEnsemble filterEnsemble_;
+  };
 
-    /** Generator abstract class.
-     *  This is a generator interface. Generators are the first step of the MC simulation: they take data from existing
-     *  files or encapsulate nucleus-nucleus collision generators.
-     */
-    class VGenerator : public VFilter {
-      public:
-        VGenerator() = default;
-        VGenerator(const VGenerator&) = delete;
-        VGenerator(VGenerator&&) = delete;
-        VGenerator& operator=(const VGenerator&) = delete;
-        VGenerator& operator=(VGenerator&&) = delete;
-        ~VGenerator() override = 0;
+  class VModule {
+   public:
+    VModule() = default;
 
-        /** A method to request one event from the generator.
-         *  Users are supposed to override this method to provide a single event from the generator model.
-         *  @return A pointer to the EventData of the produced event.
-         */
-        virtual std::unique_ptr<EventData> operator()() = 0;
-    };
+    FactoryMap GetModuleFilters(const std::optional<std::string>& prefix = std::nullopt) const;
 
-    inline VGenerator::~VGenerator() = default;
+    virtual ~VModule() = default;
 
-    /** Converter abstract class.
-     *  This is a converter interface. It is inherited by all filters that are in the middle of MC simulation.
-     *  Converters are intended to transform data from previous steps.
-     */
-    class VConverter : public VFilter {
-      public:
-        VConverter() = default;
-        VConverter(const VConverter&) = delete;
-        VConverter(VConverter&&) = delete;
-        VConverter& operator=(const VConverter&) = delete;
-        VConverter& operator=(VConverter&&) = delete;
-        ~VConverter() override = 0;
+   private:
+    virtual FactoryMap DoGetModuleFilters() const = 0;
+  };
 
-        /** A method to process one event by the converter model.
-         *  Users are supposed to override this method to process a single event by the converter model.
-         *  @param data A pointer to the EventData to be processed.
-         *  @return A pointer to the EventData of the processed event.
-         */
-        virtual std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) = 0;
-    };
+  template <typename... FilterTypes> class GenericModule : public VModule {
+   private:
+    template <typename HeadType, typename... Types> static void AddFilter(FactoryMap& factories) {
+      static_assert(std::is_base_of_v<VFactory, HeadType>, "all types must be Factories");
 
-    inline VConverter::~VConverter() = default;
+      {
+        auto factory = std::make_unique<HeadType>();
+        factories[factory->GetFilterName()] = std::move(factory);
+      }
 
-    /** Writer abstract class.
-     *  This is a writer interface. Writers are what the name suggests - they implement writing results into different
-     *  data formats. Note, that it isn't necessary to *only* write events to memory with this class. If you need to
-     *  process data in a way that the EventData is incompatible with the output (for example, you want to model a
-     *  detector response to the generated event) you can encapsulate these calculations in a writer class.
-     */
-    class VWriter : public VFilter {
-      public:
-        VWriter() = default;
-        VWriter(const VWriter&) = delete;
-        VWriter(VWriter&&) = delete;
-        VWriter& operator=(const VWriter&) = delete;
-        VWriter& operator=(VWriter&&) = delete;
-        ~VWriter() override = 0;
+      if (sizeof...(Types) > 0) {
+        AddFilter<Types...>(factories);
+      }
+    }
 
-        /** A method to save one event by the writer.
-         *  Users are supposed to override this method to save a single event. Note, that the implementation is left
-         *  to the user: you can save events to buffer with this method and write them to the filesystem in batches if
-         *  you please so.
-         *  @param data A pointer to the EventData to be saved.
-         */
-        virtual void operator()(std::unique_ptr<EventData>&& data) = 0;
-    };
+    FactoryMap DoGetModuleFilters() const override {
+      FactoryMap factories;
+      AddFilter<FilterTypes...>(factories);
+      return factories;
+    }
+  };
 
-    inline VWriter::~VWriter() = default;
-
-    /** An enum for marking Filter types.
-     */
-    enum class FilterType : char {
-        GENERATOR,
-        CONVERTER,
-        WRITER
-    };
-
-    /** Factory abstract class.
-     * This is a factory interface. It generates a Filter with its VFactory::create method. DI in COLA works via using
-     * the factory classes, which are registered in a MetaProcessor instance.
-     */
-    class VFactory {
-      public:
-        VFactory() = default;
-        VFactory(const VFactory&) = delete;
-        VFactory(VFactory&&) = delete;
-        VFactory& operator=(const VFactory&) = delete;
-        VFactory& operator=(VFactory&&) = delete;
-        virtual ~VFactory() = default;
-
-        /** The method for constructing filters.
-         *  This method is intended to be called in MetaProcessor with key-value pairs obtained from a XML-file.
-         *  @param metaData A dictionary with key-value pairs needed for configuring a model.
-         *  @return A configured class that is a VFilter child.
-         */
-        virtual std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& metaData) = 0;
-
-        virtual FilterType GetFilterType() const = 0;
-
-        virtual const std::string& GetFilterName() const = 0;
-    };
-
-    using FactoryMap = std::unordered_map<std::string, std::unique_ptr<VFactory>>;
-
-    class VGeneratorFactory : public VFactory {
-      public:
-        FilterType GetFilterType() const final {
-            return FilterType::GENERATOR;
-        }
-    };
-
-    class VConverterFactory : public VFactory {
-      public:
-        FilterType GetFilterType() const final {
-            return FilterType::CONVERTER;
-        }
-    };
-
-    class VWriterFactory : public VFactory {
-      public:
-        FilterType GetFilterType() const final {
-            return FilterType::WRITER;
-        }
-    };
-
-    template <typename Filter>
-    class GenericFactory : public VFactory {
-      private:
-        template<typename, typename = void>
-        struct HasName : std::false_type {};
-        
-        template<typename T>
-        struct HasName<T, std::void_t<decltype(T::NAME)>> : std::true_type {};
-
-        template<typename T>
-        static constexpr bool HAS_NAME = HasName<T>::value;
-
-      public:
-        GenericFactory() {
-            static_assert(std::is_base_of_v<VFilter, Filter>, "Filter template must inherit cola::VFilter");
-            static_assert(HAS_NAME<Filter>, "Filter class must have NAME class variable");
-            static_assert(std::is_same_v<std::remove_reference_t<std::remove_cv_t<decltype(Filter::NAME)>>, std::string>, "NAME variable must be a string");
-        }
-
-        std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& /* metaData */) override {
-            return std::make_unique<Filter>();
-        }
-
-        const std::string& GetFilterName() const final {
-            return Filter::NAME;
-        }
-
-        FilterType GetFilterType() const final {
-            if constexpr (std::is_base_of_v<VGenerator, Filter>) {
-                return FilterType::GENERATOR;
-            } else if constexpr (std::is_base_of_v<VConverter, Filter>) {
-                return FilterType::CONVERTER;
-            } else if constexpr (std::is_base_of_v<VWriter, Filter>) {
-                return FilterType::WRITER;
-            } else {
-                static_assert(true, "unhandled 'FilterType' value");
-            }
-        }
-    };
-
-    std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& /*generator*/,
-                                         const std::unique_ptr<VConverter>& /*converter*/);
-    std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& /*data*/,
-                                         const std::unique_ptr<VConverter>& /*converter*/);
-    void operator|(std::unique_ptr<EventData>&& /*data*/, const std::unique_ptr<VWriter>& /*writer*/);
-
-    /** @}
-     *  \defgroup Metadata Classes for constructing and running a model.
-     *  @{
-     */
-
-    /** A structure representing the model pipeline.
-     */
-    struct FilterEnsemble {
-        std::unique_ptr<VGenerator> generator;               /**< Event generator. */
-        std::vector<std::unique_ptr<VConverter>> converters; /**< Vector of converters, applied step-by-step. */
-        std::unique_ptr<VWriter> writer;                     /**< Writer to save the results. */
-    };
-
-    /** A class for processing meta information.
-     *  This class stores data about all available Filters and corresponding factory classes and uses it to create the
-     *  pipeline using its MetaProcessor:parse method to read all needed information from an XML-file.
-     */
-    class MetaProcessor {
-      public:
-        /** Default constructor.
-         */
-        MetaProcessor() = default;
-
-        /** Constructor with immediate factories registration.
-         * Note that unique pointers in the dictionary are invalidated.
-         * @param filterMap A dictionary with all relevant information. Note that unique pointers in the dictionary are
-         * invalidated.
-         */
-        explicit MetaProcessor(FactoryMap&& filterMap);
-
-        ~MetaProcessor() = default;
-
-        /** A method for registering new Filters.
-         * @param factory A rvalue-reference to the Filter factory pointer
-         * @param name The name of the Filter.
-         */
-        void Register(std::unique_ptr<VFactory>&& factory, const std::optional<std::string>& name = std::nullopt);
-
-        /** A method to parse a XML-file to set up a configured FilterEnsemble.
-         *  This method opens an XML-file @param fName to get the information to set up the model.
-         *  Inside the root element should be one <generator> element followed by any number of <converter> elements
-         *  (none is possible) and, finally, a <writer> element. Each element must have "name" attribute followed by
-         *  any number of additional attributes. These attributes are then passed to the corresponding factory's
-         * VFactory::create method as a dictionary with keys being attribute names and values - attribute values. This
-         * method throws an error if a relevant factory isn't found or XML-file is malformed.
-         *  @param fName Name with the configuration XML-file.
-         *  @return A configured FilterEnsemble.
-         */
-        FilterEnsemble Parse(const std::string& fName) const;
-
-        /** A method to parse a XML-file to set up a configured FilterEnsemble.
-         *  @param contents configuration XML-file contents
-         *  @return A configured FilterEnsemble.
-         */
-        FilterEnsemble Parse(std::istream& contents) const;
-
-      private:
-        FactoryMap generatorMap_;
-        FactoryMap converterMap_;
-        FactoryMap writerMap_;
-
-        FilterEnsemble BuildFilterEnsemble(const tinyxml2::XMLDocument& document) const;
-
-        void RegisterGenerator(std::unique_ptr<VFactory>&& factory, const std::string& name) {
-            generatorMap_.emplace(name, std::move(factory));
-        }
-        void RegisterConverter(std::unique_ptr<VFactory>&& factory, const std::string& name) {
-            converterMap_.emplace(name, std::move(factory));
-        }
-        void RegisterWriter(std::unique_ptr<VFactory>&& factory, const std::string& name) {
-            writerMap_.emplace(name, std::move(factory));
-        }
-    };
-
-    /** Manager class.
-     * Currently more of a boilerplate, but potentially useful to incorporate parallel computing.
-     */
-    class ColaRunManager {
-      public:
-        /** A constructor that moves the configured FilterEnsemble into the manager.
-         * @param ensemble Configured model.
-         */
-        explicit ColaRunManager(FilterEnsemble&& ensemble) : filterEnsemble_(std::move(ensemble)) {
-        }
-
-        ~ColaRunManager() = default;
-
-        /** A method to run the resulting model @param n times.
-         * @param n Number of runs.
-         */
-        void Run(int n = 1) const;
-
-      private:
-        FilterEnsemble filterEnsemble_;
-    };
-
-    class VModule {
-      public:
-        VModule() = default;
-
-        FactoryMap GetModuleFilters(const std::optional<std::string>& prefix = std::nullopt) const;
-
-        virtual ~VModule() = default;
-
-      private:
-        virtual FactoryMap DoGetModuleFilters() const = 0;
-    };
-
-    template <typename... FilterTypes>
-    class GenericModule : public VModule {
-      private:
-        template <typename HeadType, typename... Types>
-        static void AddFilter(FactoryMap& factories) {
-            static_assert(std::is_base_of_v<VFactory, HeadType>, "all types must be Factories");
-
-            {
-                auto factory = std::make_unique<HeadType>();
-                factories[factory->GetFilterName()] = std::move(factory);
-            }
-
-            if (sizeof...(Types) > 0) {
-                AddFilter<Types...>(factories);
-            }
-        }
-
-        FactoryMap DoGetModuleFilters() const override {
-            FactoryMap factories;
-            AddFilter<FilterTypes...>(factories);
-            return factories;
-        }
-    };
-
-    std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,
-                                              const std::optional<std::string>& libDirectory = std::nullopt);
-} // namespace cola
+  std::unique_ptr<cola::VModule> LoadModule(const std::string& moduleName,
+                                            const std::optional<std::string>& libDirectory = std::nullopt);
+}  // namespace cola
 
 extern "C" {
 /** Loads COLA module in runtime, shouldn't be used directly
@@ -470,4 +452,4 @@ extern "C" {
 cola::VModule* LoadCOLAModule();
 }
 
-#endif // COLA_COLA_HH
+#endif  // COLA_COLA_HH

--- a/COLA.hh
+++ b/COLA.hh
@@ -21,321 +21,351 @@
 #ifndef COLA_COLA_HH
 #define COLA_COLA_HH
 
-#include "LorentzVector.hh"
-
-#include <cstdint>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <vector>
 
+#include "LorentzVector.hh"
+
 namespace cola {
-  using LorentzVector = LorentzVectorImpl<double>;
+    using LorentzVector = LorentzVectorImpl<double>;
 
-  /** A typedef representing mass and charge of a nucleon.
-   */
-  using AZ = std::pair<std::uint16_t, std::uint16_t>;
-
-  /** PDG code to AZ converter.
-   *  **WARNING:** this function is intended to process heavy ions PDG codes.
-   *  @param pdgCode PDG code of the ion.
-   *  @return AZ of the ion.
-   */
-  AZ PdgToAz(int pdgCode);
-
-  /** AZ to PDG code converter.
-   *  @param data AZ of the ion.
-   *  @return PDG code of the ion
-   */
-  int AZToPdg(AZ data);
-
-  /** \defgroup Data Data Classes and supporting methods.
-   * @{
-   */
-
-  /** Particle class by generator output.
-   *  This enum represents various outcomes of a generator event for every particle.
-   */
-  enum class ParticleClass : char {
-    kProduced,    /**< A particle that was not present in the starting nuclei. */
-    kElasticA,    /**< A particle that was present in the projectile nucleus and has experienced only elastic
-                   * interactions.
-                   */
-    kElasticB,    /**< A particle that was present in the target nucleus and has experienced only elastic interactions.
-                   */
-    kNonelasticA, /**< A particle that was present in the projectile nucleus and has experienced at least one
-                    non-elastic interaction. */
-    kNonelasticB, /**< A particle that was present in the target nucleus and has experienced at least one
-                    non-elastic interaction. */
-    kSpectatorA,  /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
-                   */
-    kSpectatorB   /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
-                   */
-  };
-
-  /** Particle data.
-   *  A structure representing data about a single particle
-   */
-  struct Particle {
-    AZ GetAz() const;
-
-    LorentzVector position; /**< Position <t, x, y, z> vector. */
-
-    LorentzVector momentum; /**< Momentum <e, x, y, z> vector. */
-
-    int pdgCode;          /**< PDG code of the particle. */
-    ParticleClass pClass; /**< Data about particle origin. See ParticleClass for more info.*/
-  };
-
-  /**
-   * Convenient typedef for Particle vector.
-   */
-  using EventParticles = std::vector<Particle>;
-
-  /** Initial state data.
-   *  This structure contains data about initial state of any given event.
-   */
-  struct EventIniState {
-    int pdgCodeA; /**< PDF code of the projectile. */
-    int pdgCodeB; /**< PDF code of the target. */
-
-    double pZA;    /** Axial momentum of the projectile */
-    double pZB;    /** Axial momentum of the target */
-    double energy; /** Incidental energy of the event. Depending on pZB being zero, this is either \f$E/A\f$ of
-                      target or \f$\sqrt{s_{NN}}\f$. */
-
-    float sectNN; /** Nucleon-Nucleon cross section from generator. */
-    float b;      /** Impact parameter of the event. */
-
-    int nColl;   /** Diagnostic. Total number of collisions. */
-    int nCollPP; /** Diagnostic. Number of proton-proton. */
-    int nCollPN; /** Diagnostic. Number of proton-neutron collisions. */
-    int nCollNN; /** Diagnostic. Number of neutron-neutron collisions. */
-    int nPart;   /** Diagnostic. Total number of participants. */
-    int nPartA;  /** Diagnostic. Number of participants from the projectile nucleus. */
-    int nPartB;  /** Diagnostic. Number of participants from the target nucleus. */
-
-    float phiRotA;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the projectile nucleon. */
-    float thetaRotA; /** Diagnostic. Polar angle \f&\Theta\f$ of rotation of the projectile nucleon. */
-    float phiRotB;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the target nucleon. */
-    float thetaRotB; /** Diagnostic. Polar angle \f$\Theta\f$ of rotation of the target nucleon. */
-
-    EventParticles iniStateParticles; /** The array of all Particles just before the event. */
-  };
-
-  /** A structure combining EventIniState and EventParticles of the event.
-   */
-  struct EventData {
-    EventIniState iniState;
-    EventParticles particles;
-  };
-
-  /** @}
-   * \defgroup Interface Pure abstract classes used for dependency injection.
-   * @{
-   */
-
-  /** A common abstract parent class representing any model in the pipeline.
-   *  A single model in the COLA-driven pipeline is named a Filter.
-   */
-  class VFilter {
-   public:
-    VFilter() = default;
-    VFilter(const VFilter&) = delete;
-    VFilter(VFilter&&) = delete;
-    VFilter& operator=(const VFilter&) = delete;
-    VFilter& operator=(VFilter&&) = delete;
-    virtual ~VFilter() = 0;
-  };
-
-  inline VFilter::~VFilter() = default;
-
-  /** Generator abstract class.
-   *  This is a generator interface. Generators are the first step of the MC simulation: they take data from existing
-   *  files or encapsulate nucleus-nucleus collision generators.
-   */
-  class VGenerator : public VFilter {
-   public:
-    VGenerator() = default;
-    VGenerator(const VGenerator&) = delete;
-    VGenerator(VGenerator&&) = delete;
-    VGenerator& operator=(const VGenerator&) = delete;
-    VGenerator& operator=(VGenerator&&) = delete;
-    ~VGenerator() override = 0;
-
-    /** A method to request one event from the generator.
-     *  Users are supposed to override this method to provide a single event from the generator model.
-     *  @return A pointer to the EventData of the produced event.
+    /** A typedef representing mass and charge of a nucleon.
      */
-    virtual std::unique_ptr<EventData> operator()() = 0;
-  };
+    using AZ = std::pair<uint16_t, uint16_t>;
 
-  inline VGenerator::~VGenerator() = default;
-
-  /** Converter abstract class.
-   *  This is a converter interface. It is inherited by all filters that are in the middle of MC simulation.
-   *  Converters are intended to transform data from previous steps.
-   */
-  class VConverter : public VFilter {
-   public:
-    VConverter() = default;
-    VConverter(const VConverter&) = delete;
-    VConverter(VConverter&&) = delete;
-    VConverter& operator=(const VConverter&) = delete;
-    VConverter& operator=(VConverter&&) = delete;
-    ~VConverter() override = 0;
-
-    /** A method to process one event by the converter model.
-     *  Users are supposed to override this method to process a single event by the converter model.
-     *  @param data A pointer to the EventData to be processed.
-     *  @return A pointer to the EventData of the processed event.
+    /** PDG code to AZ converter.
+     *  **WARNING:** this function is intended to process heavy ions PDG codes.
+     *  @param pdgCode PDG code of the ion.
+     *  @return AZ of the ion.
      */
-    virtual std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) = 0;
-  };
+    AZ PdgToAz(int pdgCode);
 
-  inline VConverter::~VConverter() = default;
-
-  /** Writer abstract class.
-   *  This is a writer interface. Writers are what the name suggests - they implement writing results into different
-   *  data formats. Note, that it isn't necessary to *only* write events to memory with this class. If you need to
-   *  process data in a way that the EventData is incompatible with the output (for example, you want to model a
-   *  detector response to the generated event) you can encapsulate these calculations in a writer class.
-   */
-  class VWriter : public VFilter {
-   public:
-    VWriter() = default;
-    VWriter(const VWriter&) = delete;
-    VWriter(VWriter&&) = delete;
-    VWriter& operator=(const VWriter&) = delete;
-    VWriter& operator=(VWriter&&) = delete;
-    ~VWriter() override = 0;
-
-    /** A method to save one event by the writer.
-     *  Users are supposed to override this method to save a single event. Note, that the implementation is left
-     *  to the user: you can save events to buffer with this method and write them to the filesystem in batches if
-     *  you please so.
-     *  @param data A pointer to the EventData to be saved.
+    /** AZ to PDG code convverter.
+     *  @param data AZ of the ion.
+     *  @return PDG code of the ion
      */
-    virtual void operator()(std::unique_ptr<EventData>&& data) = 0;
-  };
+    int AZToPdg(AZ data);
 
-  inline VWriter::~VWriter() = default;
-
-  /** Factory abstract class.
-   * This is a factory interface. It generates a Filter with its VFactory::create method. DI in COLA works via using
-   * the factory classes, which are registered in a MetaProcessor instance.
-   */
-  class VFactory {
-   public:
-    VFactory() = default;
-    VFactory(const VFactory&) = delete;
-    VFactory(VFactory&&) = delete;
-    VFactory& operator=(const VFactory&) = delete;
-    VFactory& operator=(VFactory&&) = delete;
-    virtual ~VFactory() = default;
-
-    /** The method for constructing filters.
-     *  This method is intended to be called in MetaProcessor with key-value pairs obtained from a XML-file.
-     *  @param metaData A dictionary with key-value pairs needed for configuring a model.
-     *  @return A configured class that is a VFilter child.
+    /** \defgroup Data Data Classes and supporting methods.
+     * @{
      */
-    virtual VFilter* Create(const std::map<std::string, std::string>& metaData) = 0;
-  };
 
-  std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& /*generator*/,
-                                       const std::unique_ptr<VConverter>& /*converter*/);
-  std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& /*data*/,
-                                       const std::unique_ptr<VConverter>& /*converter*/);
-  void operator|(std::unique_ptr<EventData>&& /*data*/, const std::unique_ptr<VWriter>& /*writer*/);
-
-  /** An enum for marking Filter types.
-   */
-  enum class FilterType : char { kGenerator, kConverter, kWriter };
-  /** @}
-   *  \defgroup Metadata Classes for constructing and running a model.
-   *  @{
-   */
-
-  /** A structure representing the model pipeline.
-   */
-  struct FilterEnsemble {
-    std::unique_ptr<VGenerator> generator;               /**< Event generator. */
-    std::vector<std::unique_ptr<VConverter>> converters; /**< Vector of converters, applied step-by-step. */
-    std::unique_ptr<VWriter> writer;                     /**< Writer to save the results. */
-  };
-
-  /** A class for processing meta information.
-   *  This class stores data about all available Filters and corresponding factory classes and uses it to create the
-   *  pipeline using its MetaProcessor:parse method to read all needed information from an XML-file.
-   */
-  class MetaProcessor {
-   public:
-    /** Default constructor.
+    /** Particle class by generator output.
+     *  This enum represents various outcomes of a generator event for every particle.
      */
-    MetaProcessor() = default;
+    enum class ParticleClass : char {
+        PRODUCED,  /**< A particle that was not present in the starting nuclei. */
+        ELASTIC_A, /**< A particle that was present in the projectile nucleus and has experienced only elastic
+                    * interactions.
+                    */
+        ELASTIC_B, /**< A particle that was present in the target nucleus and has experienced only elastic interactions.
+                    */
+        NONELASTIC_A, /**< A particle that was present in the projectile nucleus and has experienced at least one
+                        non-elastic interaction. */
+        NONELASTIC_B, /**< A particle that was present in the target nucleus and has experienced at least one
+                        non-elastic interaction. */
+        SPECTATOR_A, /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
+                      */
+        SPECTATOR_B  /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
+                      */
+    };
 
-    /** Constructor with immediate factories registration.
-     * Note that unique pointers in the dictionary are invalidated.
-     * @param filterMap A dictionary with all relevant information. Note that unique pointers in the dictionary are
-     * invalidated.
+    /** Particle data.
+     *  A structure representing data about a single particle
      */
-    explicit MetaProcessor(std::map<std::string, std::pair<std::unique_ptr<VFactory>, FilterType>>& filterMap);
+    struct Particle {
+        AZ GetAz() const;
 
-    ~MetaProcessor() = default;
+        LorentzVector position; /**< Position <t, x, y, z> vector. */
 
-    /** A method for registering new Filters.
-     * @param factory A rvalue-reference to the Filter factory pointer
-     * @param name The name of the Filter.
-     * @param type The type of the Filter. See FilterType.
+        LorentzVector momentum; /**< Momentum <e, x, y, z> vector. */
+
+        int pdgCode;          /**< PDG code of the particle. */
+        ParticleClass pClass; /**< Data about particle origin. See ParticleClass for more info.*/
+    };
+
+    /**
+     * Convenient typedef for Particle vector.
      */
-    void Reg(std::unique_ptr<VFactory>&& factory, const std::string& name, FilterType type);
+    using EventParticles = std::vector<Particle>;
 
-    /** A method to parse a XML-file to set up a configured FilterEnsemble.
-     *  This method opens an XML-file @param fName to get the information to set up the model.
-     *  Inside the root element should be one <generator> element followed by any number of <converter> elements
-     *  (none is possible) and, finally, a <writer> element. Each element must have "name" attribute followed by
-     *  any number of additional attributes. These attributes are then passed to the corresponding factory's
-     * VFactory::create method as a dictionary with keys being attribute names and values - attribute values. This
-     * method throws an error if a relevant factory isn't found or XML-file is malformed.
-     *  @param fName Name with the configuration XML-file.
-     *  @return A configured FilterEnsemble.
+    /** Initial state data.
+     *  This structure contains data about initial state of any given event.
      */
-    FilterEnsemble Parse(const std::string& fName) const;
+    struct EventIniState {
+        int pdgCodeA; /**< PDF code of the projectile. */
+        int pdgCodeB; /**< PDF code of the target. */
 
-   private:
-    std::map<std::string, std::unique_ptr<VFactory>> generatorMap_;
-    std::map<std::string, std::unique_ptr<VFactory>> converterMap_;
-    std::map<std::string, std::unique_ptr<VFactory>> writerMap_;
+        double pZA;    /** Axial momentum of the projectile */
+        double pZB;    /** Axial momentum of the target */
+        double energy; /** Incidental energy of the event. Depending on pZB being zero, this is either \f$E/A\f$ of
+                          target or \f$\sqrt{s_{NN}}\f$. */
 
-    void RegGen(std::unique_ptr<VFactory>&& factory, const std::string& name) {
-      generatorMap_.emplace(name, std::move(factory));
-    }
-    void RegConv(std::unique_ptr<VFactory>&& factory, const std::string& name) {
-      converterMap_.emplace(name, std::move(factory));
-    }
-    void RegWrite(std::unique_ptr<VFactory>&& factory, const std::string& name) {
-      writerMap_.emplace(name, std::move(factory));
-    }
-  };
+        float sectNN; /** Nucleon-Nucleon cross section from generator. */
+        float b;      /** Impact parameter of the event. */
 
-  /** Manager class.
-   * Currently more of a boilerplate, but potentially useful to incorporate parallel computing.
-   */
-  class ColaRunManager {
-   public:
-    ColaRunManager() = delete;
-    /** A constructor that moves the configured FilterEnsemble into the manager.
-     * @param ensemble Configured model.
+        int nColl;   /** Diagnostic. Total number of collisions. */
+        int nCollPP; /** Diagnostic. Number of proton-proton. */
+        int nCollPN; /** Diagnostic. Number of proton-neutron collisions. */
+        int nCollNN; /** Diagnostic. Number of neutron-neutron collisions. */
+        int nPart;   /** Diagnostic. Total number of participants. */
+        int nPartA;  /** Diagnostic. Number of participants from the projectile nucleus. */
+        int nPartB;  /** Diagnostic. Number of participants from the target nucleus. */
+
+        float phiRotA;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the projectile nucleon. */
+        float thetaRotA; /** Diagnostic. Polar angle \f&\Theta\f$ of rotation of the projectile nucleon. */
+        float phiRotB;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the target nucleon. */
+        float thetaRotB; /** Diagnostic. Polar angle \f$\Theta\f$ of rotation of the target nucleon. */
+
+        EventParticles iniStateParticles; /** The array of all Particles just before the event. */
+    };
+
+    /** A structure combining EventIniState and EventParticles of the event.
      */
-    explicit ColaRunManager(FilterEnsemble&& ensemble) : filterEnsemble_(std::move(ensemble)) {}
-    ~ColaRunManager() = default;
-    /** A method to run the resulting model @param n times.
-     * @param n Number of runs.
+    struct EventData {
+        EventIniState iniState;
+        EventParticles particles;
+    };
+
+    /** @}
+     * \defgroup Interface Pure abstract classes used for dependency injection.
+     * @{
      */
-    void Run(int n = 1) const;
 
-   private:
-    FilterEnsemble filterEnsemble_;
-  };
-}  // namespace cola
+    /** A common abstract parent class representing any model in the pipeline.
+     *  A single model in the COLA-driven pipeline is named a Filter.
+     */
+    class VFilter {
+      public:
+        VFilter() = default;
+        VFilter(const VFilter&) = delete;
+        VFilter(VFilter&&) = delete;
+        VFilter& operator=(const VFilter&) = delete;
+        VFilter& operator=(VFilter&&) = delete;
+        virtual ~VFilter() = 0;
+    };
 
-#endif  // COLA_COLA_HH
+    inline VFilter::~VFilter() = default;
+
+    /** Generator abstract class.
+     *  This is a generator interface. Generators are the first step of the MC simulation: they take data from existing
+     *  files or encapsulate nucleus-nucleus collision generators.
+     */
+    class VGenerator : public VFilter {
+      public:
+        VGenerator() = default;
+        VGenerator(const VGenerator&) = delete;
+        VGenerator(VGenerator&&) = delete;
+        VGenerator& operator=(const VGenerator&) = delete;
+        VGenerator& operator=(VGenerator&&) = delete;
+        ~VGenerator() override = 0;
+
+        /** A method to request one event from the generator.
+         *  Users are supposed to override this method to provide a single event from the generator model.
+         *  @return A pointer to the EventData of the produced event.
+         */
+        virtual std::unique_ptr<EventData> operator()() = 0;
+    };
+
+    inline VGenerator::~VGenerator() = default;
+
+    /** Converter abstract class.
+     *  This is a converter interface. It is inherited by all filters that are in the middle of MC simulation.
+     *  Converters are intended to transform data from previous steps.
+     */
+    class VConverter : public VFilter {
+      public:
+        VConverter() = default;
+        VConverter(const VConverter&) = delete;
+        VConverter(VConverter&&) = delete;
+        VConverter& operator=(const VConverter&) = delete;
+        VConverter& operator=(VConverter&&) = delete;
+        ~VConverter() override = 0;
+
+        /** A method to process one event by the converter model.
+         *  Users are supposed to override this method to process a single event by the converter model.
+         *  @param data A pointer to the EventData to be processed.
+         *  @return A pointer to the EventData of the processed event.
+         */
+        virtual std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) = 0;
+    };
+
+    inline VConverter::~VConverter() = default;
+
+    /** Writer abstract class.
+     *  This is a writer interface. Writers are what the name suggests - they implement writing results into different
+     *  data formats. Note, that it isn't necessary to *only* write events to memory with this class. If you need to
+     *  process data in a way that the EventData is incompatible with the output (for example, you want to model a
+     *  detector response to the generated event) you can encapsulate these calculations in a writer class.
+     */
+    class VWriter : public VFilter {
+      public:
+        VWriter() = default;
+        VWriter(const VWriter&) = delete;
+        VWriter(VWriter&&) = delete;
+        VWriter& operator=(const VWriter&) = delete;
+        VWriter& operator=(VWriter&&) = delete;
+        ~VWriter() override = 0;
+
+        /** A method to save one event by the writer.
+         *  Users are supposed to override this method to save a single event. Note, that the implementation is left
+         *  to the user: you can save events to buffer with this method and write them to the filesystem in batches if
+         *  you please so.
+         *  @param data A pointer to the EventData to be saved.
+         */
+        virtual void operator()(std::unique_ptr<EventData>&& data) = 0;
+    };
+
+    inline VWriter::~VWriter() = default;
+
+    /** An enum for marking Filter types.
+     */
+    enum class FilterType : char {
+        GENERATOR,
+        CONVERTER,
+        WRITER
+    };
+
+    /** Factory abstract class.
+     * This is a factory interface. It generates a Filter with its VFactory::create method. DI in COLA works via using
+     * the factory classes, which are registered in a MetaProcessor instance.
+     */
+    class VFactory {
+      public:
+        VFactory() = default;
+        VFactory(const VFactory&) = delete;
+        VFactory(VFactory&&) = delete;
+        VFactory& operator=(const VFactory&) = delete;
+        VFactory& operator=(VFactory&&) = delete;
+        virtual ~VFactory() = default;
+
+        /** The method for constructing filters.
+         *  This method is intended to be called in MetaProcessor with key-value pairs obtained from a XML-file.
+         *  @param metaData A dictionary with key-value pairs needed for configuring a model.
+         *  @return A configured class that is a VFilter child.
+         */
+        virtual std::unique_ptr<VFilter> Create(const std::unordered_map<std::string, std::string>& metaData) = 0;
+
+        virtual FilterType GetFilterType() const = 0;
+    };
+
+    using FactoryMap = std::unordered_map<std::string, std::unique_ptr<VFactory>>;
+
+    class VGeneratorFactory: public VFactory {
+      public:
+        FilterType GetFilterType() const final {
+          return FilterType::GENERATOR;
+        }
+    };
+
+    class VConverterFactory: public VFactory {
+      public:
+        FilterType GetFilterType() const final {
+          return FilterType::CONVERTER;
+        }
+    };
+
+    class VWriterFactory: public VFactory {
+      public:
+        FilterType GetFilterType() const final {
+          return FilterType::WRITER;
+        }
+    };
+
+    std::unique_ptr<EventData> operator|(const std::unique_ptr<VGenerator>& /*generator*/,
+                                         const std::unique_ptr<VConverter>& /*converter*/);
+    std::unique_ptr<EventData> operator|(std::unique_ptr<EventData>&& /*data*/,
+                                         const std::unique_ptr<VConverter>& /*converter*/);
+    void operator|(std::unique_ptr<EventData>&& /*data*/, const std::unique_ptr<VWriter>& /*writer*/);
+
+    /** @}
+     *  \defgroup Metadata Classes for constructing and running a model.
+     *  @{
+     */
+
+    /** A structure representing the model pipeline.
+     */
+    struct FilterEnsemble {
+        std::unique_ptr<VGenerator> generator;               /**< Event generator. */
+        std::vector<std::unique_ptr<VConverter>> converters; /**< Vector of converters, applied step-by-step. */
+        std::unique_ptr<VWriter> writer;                     /**< Writer to save the results. */
+    };
+
+    /** A class for processing meta information.
+     *  This class stores data about all available Filters and corresponding factory classes and uses it to create the
+     *  pipeline using its MetaProcessor:parse method to read all needed information from an XML-file.
+     */
+    class MetaProcessor {
+      public:
+        /** Default constructor.
+         */
+        MetaProcessor() = default;
+
+        /** Constructor with immediate factories registration.
+         * Note that unique pointers in the dictionary are invalidated.
+         * @param filterMap A dictionary with all relevant information. Note that unique pointers in the dictionary are
+         * invalidated.
+         */
+        explicit MetaProcessor(FactoryMap&& filterMap);
+
+        ~MetaProcessor() = default;
+
+        /** A method for registering new Filters.
+         * @param factory A rvalue-reference to the Filter factory pointer
+         * @param name The name of the Filter.
+         */
+        void Register(std::unique_ptr<VFactory>&& factory, const std::string& name);
+
+        /** A method to parse a XML-file to set up a configured FilterEnsemble.
+         *  This method opens an XML-file @param fName to get the information to set up the model.
+         *  Inside the root element should be one <generator> element followed by any number of <converter> elements
+         *  (none is possible) and, finally, a <writer> element. Each element must have "name" attribute followed by
+         *  any number of additional attributes. These attributes are then passed to the corresponding factory's
+         * VFactory::create method as a dictionary with keys being attribute names and values - attribute values. This
+         * method throws an error if a relevant factory isn't found or XML-file is malformed.
+         *  @param fName Name with the configuration XML-file.
+         *  @return A configured FilterEnsemble.
+         */
+        FilterEnsemble Parse(const std::string& fName) const;
+
+      private:
+        FactoryMap generatorMap_;
+        FactoryMap converterMap_;
+        FactoryMap writerMap_;
+
+        void RegisterGenerator(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+            generatorMap_.emplace(name, std::move(factory));
+        }
+        void RegisterConverter(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+            converterMap_.emplace(name, std::move(factory));
+        }
+        void RegisterWriter(std::unique_ptr<VFactory>&& factory, const std::string& name) {
+            writerMap_.emplace(name, std::move(factory));
+        }
+    };
+
+    /** Manager class.
+     * Currently more of a boilerplate, but potentially useful to incorporate parallel computing.
+     */
+    class ColaRunManager {
+      public:
+        /** A constructor that moves the configured FilterEnsemble into the manager.
+         * @param ensemble Configured model.
+         */
+        explicit ColaRunManager(FilterEnsemble&& ensemble) : filterEnsemble_(std::move(ensemble)) {
+        }
+
+        ~ColaRunManager() = default;
+
+        /** A method to run the resulting model @param n times.
+         * @param n Number of runs.
+         */
+        void Run(int n = 1) const;
+
+      private:
+        FilterEnsemble filterEnsemble_;
+    };
+} // namespace cola
+
+#endif // COLA_COLA_HH

--- a/COLA.hh
+++ b/COLA.hh
@@ -21,7 +21,7 @@
 #ifndef COLA_COLA_HH
 #define COLA_COLA_HH
 
-#include "LorentzVector.hh"
+#include "COLA/EventData.hh"
 
 #include <memory>
 #include <optional>
@@ -34,108 +34,7 @@ namespace tinyxml2 {
 }  // namespace tinyxml2
 
 namespace cola {
-  using LorentzVector = LorentzVectorImpl<double>;
-
-  /** A typedef representing mass and charge of a nucleon.
-   */
-  using AZ = std::pair<uint16_t, uint16_t>;
-
-  /** PDG code to AZ converter.
-   *  **WARNING:** this function is intended to process heavy ions PDG codes.
-   *  @param pdgCode PDG code of the ion.
-   *  @return AZ of the ion.
-   */
-  AZ PdgToAZ(int pdgCode);
-
-  /** AZ to PDG code convverter.
-   *  @param data AZ of the ion.
-   *  @return PDG code of the ion
-   */
-  int AZToPdg(AZ data);
-
-  /** \defgroup Data Data Classes and supporting methods.
-   * @{
-   */
-
-  /** Particle class by generator output.
-   *  This enum represents various outcomes of a generator event for every particle.
-   */
-  enum class ParticleClass : char {
-    kProduced,    /**< A particle that was not present in the starting nuclei. */
-    kElasticA,    /**< A particle that was present in the projectile nucleus and has experienced only elastic
-                   * interactions.
-                   */
-    kElasticB,    /**< A particle that was present in the target nucleus and has experienced only elastic interactions.
-                   */
-    kNonelasticA, /**< A particle that was present in the projectile nucleus and has experienced at least one
-                    non-elastic interaction. */
-    kNonelasticB, /**< A particle that was present in the target nucleus and has experienced at least one
-                    non-elastic interaction. */
-    kSpectatorA,  /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
-                   */
-    kSpectatorB   /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
-                   */
-  };
-
-  /** Particle data.
-   *  A structure representing data about a single particle
-   */
-  struct Particle {
-    AZ GetAZ() const;
-
-    LorentzVector position; /**< Position <t, x, y, z> vector. */
-
-    LorentzVector momentum; /**< Momentum <e, x, y, z> vector. */
-
-    int pdgCode;          /**< PDG code of the particle. */
-    ParticleClass pClass; /**< Data about particle origin. See ParticleClass for more info.*/
-  };
-
-  /**
-   * Convenient typedef for Particle vector.
-   */
-  using EventParticles = std::vector<Particle>;
-
-  /** Initial state data.
-   *  This structure contains data about initial state of any given event.
-   */
-  struct EventIniState {
-    int pdgCodeA; /**< PDF code of the projectile. */
-    int pdgCodeB; /**< PDF code of the target. */
-
-    double pZA;    /** Axial momentum of the projectile */
-    double pZB;    /** Axial momentum of the target */
-    double energy; /** Incidental energy of the event. Depending on pZB being zero, this is either \f$E/A\f$ of
-                      target or \f$\sqrt{s_{NN}}\f$. */
-
-    float sectNN; /** Nucleon-Nucleon cross section from generator. */
-    float b;      /** Impact parameter of the event. */
-
-    int nColl;   /** Diagnostic. Total number of collisions. */
-    int nCollPP; /** Diagnostic. Number of proton-proton. */
-    int nCollPN; /** Diagnostic. Number of proton-neutron collisions. */
-    int nCollNN; /** Diagnostic. Number of neutron-neutron collisions. */
-    int nPart;   /** Diagnostic. Total number of participants. */
-    int nPartA;  /** Diagnostic. Number of participants from the projectile nucleus. */
-    int nPartB;  /** Diagnostic. Number of participants from the target nucleus. */
-
-    float phiRotA;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the projectile nucleon. */
-    float thetaRotA; /** Diagnostic. Polar angle \f&\Theta\f$ of rotation of the projectile nucleon. */
-    float phiRotB;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the target nucleon. */
-    float thetaRotB; /** Diagnostic. Polar angle \f$\Theta\f$ of rotation of the target nucleon. */
-
-    EventParticles iniStateParticles; /** The array of all Particles just before the event. */
-  };
-
-  /** A structure combining EventIniState and EventParticles of the event.
-   */
-  struct EventData {
-    EventIniState iniState;
-    EventParticles particles;
-  };
-
-  /** @}
-   * \defgroup Interface Pure abstract classes used for dependency injection.
+  /** \defgroup Interface Pure abstract classes used for dependency injection.
    * @{
    */
 
@@ -271,13 +170,17 @@ namespace cola {
     FilterType GetFilterType() const final { return FilterType::kWriter; }
   };
 
-  template <typename Filter> class GenericFactory : public VFactory {
+  template <typename Filter>
+  class GenericFactory : public VFactory {
    private:
-    template <typename, typename = void> struct HasName : std::false_type {};
+    template <typename, typename = void>
+    struct HasName : std::false_type {};
 
-    template <typename T> struct HasName<T, std::void_t<decltype(T::kName)>> : std::true_type {};
+    template <typename T>
+    struct HasName<T, std::void_t<decltype(T::kName)>> : std::true_type {};
 
-    template <typename T> static constexpr bool kHasName = HasName<T>::value;
+    template <typename T>
+    static constexpr bool kHasName = HasName<T>::value;
 
    public:
     GenericFactory() {
@@ -419,9 +322,11 @@ namespace cola {
     virtual FactoryMap DoGetModuleFilters() const = 0;
   };
 
-  template <typename... FilterTypes> class GenericModule : public VModule {
+  template <typename... FilterTypes>
+  class GenericModule : public VModule {
    private:
-    template <typename HeadType, typename... Types> static void AddFilter(FactoryMap& factories) {
+    template <typename HeadType, typename... Types>
+    static void AddFilter(FactoryMap& factories) {
       static_assert(std::is_base_of_v<VFactory, HeadType>, "all types must be Factories");
 
       {

--- a/COLA/EventData.hh
+++ b/COLA/EventData.hh
@@ -93,8 +93,8 @@ namespace cola {
    *  This structure contains data about initial state of any given event.
    */
   struct EventIniState {
-    int pdgCodeA; /**< PDF code of the projectile. */
-    int pdgCodeB; /**< PDF code of the target. */
+    int pdgCodeA; /**< PDG code of the projectile. */
+    int pdgCodeB; /**< PDG code of the target. */
 
     double pZA;    /** Axial momentum of the projectile */
     double pZB;    /** Axial momentum of the target */

--- a/COLA/EventData.hh
+++ b/COLA/EventData.hh
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2024-2025 Alexandr Svetlichnyi, Savva Savenkov, Artemii Novikov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef COLA_EVENTDATA_HH
+#define COLA_EVENTDATA_HH
+
+#include "LorentzVector.hh"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace cola {
+  using LorentzVector = LorentzVectorImpl<double>;
+
+  /** A typedef representing mass and charge of a nucleon.
+   */
+  using AZ = std::pair<uint16_t, uint16_t>;
+
+  /** PDG code to AZ converter.
+   *  **WARNING:** this function is intended to process heavy ions PDG codes.
+   *  @param pdgCode PDG code of the ion.
+   *  @return AZ of the ion.
+   */
+  AZ PdgToAZ(int pdgCode);
+
+  /** AZ to PDG code converter.
+   *  @param data AZ of the ion.
+   *  @return PDG code of the ion
+   */
+  int AZToPdg(AZ data);
+
+  /** \defgroup Data Data Classes and supporting methods.
+   * @{
+   */
+
+  /** Particle class by generator output.
+   *  This enum represents various outcomes of a generator event for every particle.
+   */
+  enum class ParticleClass : char {
+    kProduced,    /**< A particle that was not present in the starting nuclei. */
+    kElasticA,    /**< A particle that was present in the projectile nucleus and has experienced only elastic
+                   * interactions.
+                   */
+    kElasticB,    /**< A particle that was present in the target nucleus and has experienced only elastic interactions.
+                   */
+    kNonelasticA, /**< A particle that was present in the projectile nucleus and has experienced at least one
+                    non-elastic interaction. */
+    kNonelasticB, /**< A particle that was present in the target nucleus and has experienced at least one
+                    non-elastic interaction. */
+    kSpectatorA,  /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
+                   */
+    kSpectatorB   /**< A particle that was present in the projectile nucleus and hasn't experienced any interactions.
+                   */
+  };
+
+  /** Particle data.
+   *  A structure representing data about a single particle
+   */
+  struct Particle {
+    AZ GetAZ() const;
+
+    LorentzVector position; /**< Position <t, x, y, z> vector. */
+
+    LorentzVector momentum; /**< Momentum <e, x, y, z> vector. */
+
+    int pdgCode;          /**< PDG code of the particle. */
+    ParticleClass pClass; /**< Data about particle origin. See ParticleClass for more info.*/
+  };
+
+  /**
+   * Convenient typedef for Particle vector.
+   */
+  using EventParticles = std::vector<Particle>;
+
+  /** Initial state data.
+   *  This structure contains data about initial state of any given event.
+   */
+  struct EventIniState {
+    int pdgCodeA; /**< PDF code of the projectile. */
+    int pdgCodeB; /**< PDF code of the target. */
+
+    double pZA;    /** Axial momentum of the projectile */
+    double pZB;    /** Axial momentum of the target */
+    double energy; /** Incidental energy of the event. Depending on pZB being zero, this is either \f$E/A\f$ of
+                      target or \f$\sqrt{s_{NN}}\f$. */
+
+    float sectNN; /** Nucleon-Nucleon cross section from generator. */
+    float b;      /** Impact parameter of the event. */
+
+    int nColl;   /** Diagnostic. Total number of collisions. */
+    int nCollPP; /** Diagnostic. Number of proton-proton. */
+    int nCollPN; /** Diagnostic. Number of proton-neutron collisions. */
+    int nCollNN; /** Diagnostic. Number of neutron-neutron collisions. */
+    int nPart;   /** Diagnostic. Total number of participants. */
+    int nPartA;  /** Diagnostic. Number of participants from the projectile nucleus. */
+    int nPartB;  /** Diagnostic. Number of participants from the target nucleus. */
+
+    float phiRotA;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the projectile nucleon. */
+    float thetaRotA; /** Diagnostic. Polar angle \f&\Theta\f$ of rotation of the projectile nucleon. */
+    float phiRotB;   /** Diagnostic. Polar angle \f$\phi\f$ of rotation of the target nucleon. */
+    float thetaRotB; /** Diagnostic. Polar angle \f$\Theta\f$ of rotation of the target nucleon. */
+
+    EventParticles iniStateParticles; /** The array of all Particles just before the event. */
+  };
+
+  /** A structure combining EventIniState and EventParticles of the event.
+   */
+  struct EventData {
+    EventIniState iniState;
+    EventParticles particles;
+  };
+
+  /** @}
+   */
+
+}  // namespace cola
+
+#endif  // COLA_EVENTDATA_HH

--- a/COLA/EventData.hh
+++ b/COLA/EventData.hh
@@ -38,13 +38,41 @@ namespace cola {
    *  @param pdgCode PDG code of the ion.
    *  @return AZ of the ion.
    */
-  AZ PdgToAZ(int pdgCode);
+  constexpr AZ PdgToAZ(int pdgCode) {
+    switch (pdgCode) {
+      case 2112:
+        return {1, 0};
+      case 2212:
+        return {1, 1};
+      default: {
+        AZ data = {0, 0};
+        pdgCode /= 10;
+        for (int i = 0; i < 3; i++) {
+          data.first += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+          pdgCode /= 10;
+        }
+        for (int i = 0; i < 3; i++) {
+          data.second += pdgCode % 10 * static_cast<uint16_t>(std::pow(10, i));
+          pdgCode /= 10;
+        }
+        return data;
+      }
+    }
+  }
 
   /** AZ to PDG code converter.
    *  @param data AZ of the ion.
    *  @return PDG code of the ion
    */
-  int AZToPdg(AZ data);
+  constexpr int AZToPdg(AZ data) {
+    if (data.first == 1 && data.second == 0) {
+      return 2112;
+    }
+    if (data.first == 1 && data.second == 1) {
+      return 2212;
+    }
+    return 1000000000 + data.first * 10 + data.second * 10000;
+  }
 
   /** \defgroup Data Data Classes and supporting methods.
    * @{

--- a/COLA/LorentzVector.hh
+++ b/COLA/LorentzVector.hh
@@ -1,21 +1,20 @@
 /**
  * Copyright (c) 2024-2025 Alexandr Svetlichnyi, Savva Savenkov, Artemii Novikov
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
- * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 #ifndef COLA_LORENTZVECTOR_HH
@@ -23,15 +22,22 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
+#include <stdexcept>
 
 namespace cola {
 
-  template <typename Type = double> struct Vector3 {
+  template <typename Type = double>
+  struct Vector3 {
     Type x, y, z;
   };
 
-  template <typename Type = double> class LorentzVectorImpl {
+  template <typename Type>
+  Vector3<Type> RotateUz(Vector3<Type> stVec, Vector3<Type> uzVec);
+
+  template <typename Type = double>
+  class LorentzVectorImpl {
    public:
     union {
       Type e;
@@ -102,15 +108,15 @@ namespace cola {
         // calculate direction vector coordinates
         Type b1 = std::sqrt(b2);
         Vector3<Type> r_vec{bx / b1, by / b1, bz / b1};
-        Vector3<Type> r_back = rotateUz({0, 0, 1}, r_vec);
+        Vector3<Type> r_back = RotateUz({0, 0, 1}, r_vec);
 
         // rotate space vector so that boost direction is {0, 0, 1} in new coordinates
-        auto new_coord = rotateUz({x, y, z}, r_vec);
+        auto new_coord = RotateUz({x, y, z}, r_vec);
         x = new_coord.x, y = new_coord.y, z = new_coord.z;
 
         BoostAxisRapidity(std::atanh(b1));  // boost along Oz
         // rotate back
-        new_coord = rotateUz({x, y, z}, r_back);
+        new_coord = RotateUz({x, y, z}, r_back);
         x = new_coord.x, y = new_coord.y, z = new_coord.z;
       }
 
@@ -176,20 +182,24 @@ namespace cola {
     return res;
   }
 
-  template <typename Type> bool operator==(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+  template <typename Type>
+  bool operator==(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
     return a.e == b.e && a.x == b.x && a.y == b.y && a.z == b.z;
   }
 
-  template <typename Type> bool operator!=(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+  template <typename Type>
+  bool operator!=(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
     return !(a == b);
   }
 
-  template <typename Type> std::ostream& operator<<(std::ostream& out, const LorentzVectorImpl<Type>& vec) {
+  template <typename Type>
+  std::ostream& operator<<(std::ostream& out, const LorentzVectorImpl<Type>& vec) {
     out << "(" << vec.e << ", " << vec.x << ", " << vec.y << ", " << vec.z << ")";
     return out;
   }
 
-  template <typename Type> Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec) {
+  template <typename Type>
+  Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec) {
     // NewUzVector must be normalized !
 
     Vector3<Type> res_vec;

--- a/COLA/LorentzVector.hh
+++ b/COLA/LorentzVector.hh
@@ -214,7 +214,7 @@ namespace cola {
       res_vec.x = -stVec.x;
       res_vec.y = stVec.y;
       res_vec.z = -stVec.z;
-    }  // phi=0  teta=pi
+    }  // phi=0  theta=pi
 
     return res_vec;
   }

--- a/LorentzVector.hh
+++ b/LorentzVector.hh
@@ -49,41 +49,41 @@ namespace cola {
       private:
         using FieldPtr = Type LorentzVectorImpl::*;
 
-        static constexpr std::array<FieldPtr, 4> Fields = {&LorentzVectorImpl::e, &LorentzVectorImpl::x,
+        static constexpr std::array<FieldPtr, 4> FIELDS = {&LorentzVectorImpl::e, &LorentzVectorImpl::x,
                                                            &LorentzVectorImpl::y, &LorentzVectorImpl::z};
 
       public:
         const Type& operator[](int i) const {
-            return this->*Fields[i];
+            return this->*FIELDS[i];
         }
         Type& operator[](int i) {
-            return this->*Fields[i];
+            return this->*FIELDS[i];
         }
 
         LorentzVectorImpl& operator+=(const LorentzVectorImpl& other) {
-            for (size_t i = 0; i < Fields.size(); ++i) {
-                this->*Fields[i] += other.*Fields[i];
+            for (size_t i = 0; i < FIELDS.size(); ++i) {
+                this->*FIELDS[i] += other.*FIELDS[i];
             }
             return *this;
         }
 
         LorentzVectorImpl& operator-=(const LorentzVectorImpl& other) {
-            for (size_t i = 0; i < Fields.size(); ++i) {
-                this->*Fields[i] -= other.*Fields[i];
+            for (size_t i = 0; i < FIELDS.size(); ++i) {
+                this->*FIELDS[i] -= other.*FIELDS[i];
             }
             return *this;
         }
 
         LorentzVectorImpl& operator*=(Type scalar) {
-            for (size_t i = 0; i < Fields.size(); ++i) {
-                this->*Fields[i] *= scalar;
+            for (size_t i = 0; i < FIELDS.size(); ++i) {
+                this->*FIELDS[i] *= scalar;
             }
             return *this;
         }
 
         LorentzVectorImpl& operator/=(Type scalar) {
-            for (size_t i = 0; i < Fields.size(); ++i) {
-                this->*Fields[i] /= scalar;
+            for (size_t i = 0; i < FIELDS.size(); ++i) {
+                this->*FIELDS[i] /= scalar;
             }
             return *this;
         }
@@ -138,10 +138,10 @@ namespace cola {
                 throw std::runtime_error(
                     "Rapidity calculation only viable for space-like 4-vectors. Use boost() instead");
             }
-            Type inv = std::sqrt(e * e - this->*Fields[axis] * this->*Fields[axis]);
-            Type rRapidity = rapidity + .5 * (std::log(e + this->*Fields[axis]) - std::log(e - this->*Fields[axis]));
+            Type inv = std::sqrt(e * e - this->*FIELDS[axis] * this->*FIELDS[axis]);
+            Type rRapidity = rapidity + .5 * (std::log(e + this->*FIELDS[axis]) - std::log(e - this->*FIELDS[axis]));
             e = inv * std::cosh(rRapidity);
-            this->*Fields[axis] = inv * std::sinh(rRapidity);
+            this->*FIELDS[axis] = inv * std::sinh(rRapidity);
 
             return *this;
         }

--- a/LorentzVector.hh
+++ b/LorentzVector.hh
@@ -32,9 +32,6 @@ namespace cola {
         Type x, y, z;
     };
 
-    template <typename Type>
-    Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec);
-
     template <typename Type = double>
     class LorentzVectorImpl {
       public:
@@ -112,15 +109,15 @@ namespace cola {
                 // calculate direction vector coordinates
                 Type b1 = std::sqrt(b2);
                 Vector3<Type> rVec{bx / b1, by / b1, bz / b1};
-                Vector3<Type> rBack = RotateUz({0, 0, 1}, rVec);
+                Vector3<Type> rBack = rotateUz({0, 0, 1}, rVec);
 
                 // rotate space vector so that boost direction is {0, 0, 1} in new coordinates
-                auto newCoord = RotateUz({x, y, z}, rVec);
+                auto newCoord = rotateUz({x, y, z}, rVec);
                 x = newCoord.x, y = newCoord.y, z = newCoord.z;
 
                 BoostAxisRapidity(std::atanh(b1)); // boost along Oz
                 // rotate back
-                newCoord = RotateUz({x, y, z}, rBack);
+                newCoord = rotateUz({x, y, z}, rBack);
                 x = newCoord.x, y = newCoord.y, z = newCoord.z;
             }
 

--- a/LorentzVector.hh
+++ b/LorentzVector.hh
@@ -27,309 +27,212 @@
 
 namespace cola {
 
-  template <typename Type = double> class Vector3 {
-   public:
-    Type x, y, z;
-
-   private:
-    using FieldPtr = Type Vector3::*;
-
-    static constexpr std::array<FieldPtr, 3> kFields = {&Vector3::x, &Vector3::y, &Vector3::z};
-
-   public:
-    const Type& operator[](int i) const { return this->*kFields[i]; }
-    Type& operator[](int i) { return this->*kFields[i]; }
-
-    std::enable_if_t<std::is_arithmetic_v<Type>, Vector3&> operator+=(const Vector3& other) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] += other.*kFields[i];
-      }
-      return *this;
-    }
-
-    std::enable_if_t<std::is_arithmetic_v<Type>, Vector3&> operator-=(const Vector3& other) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] -= other.*kFields[i];
-      }
-      return *this;
-    }
-
-    std::enable_if_t<std::is_arithmetic_v<Type>, Vector3&> operator*=(Type scalar) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] *= scalar;
-      }
-      return *this;
-    }
-
-    std::enable_if_t<std::is_arithmetic_v<Type>, Vector3&> operator/=(Type scalar) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] /= scalar;
-      }
-      return *this;
-    }
-
-    std::enable_if_t<std::is_arithmetic_v<Type>, Type> Mag2() const { return x * x + y * y + z * z; }
-    std::enable_if_t<std::is_arithmetic_v<Type>, Type> Mag() const { return std::sqrt(Mag2()); }
-  };
-
-  template <typename Type>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> operator+(const Vector3<Type>& a,
-                                                                        const Vector3<Type>& b) {
-    auto res = a;
-    res += b;
-    return res;
-  }
-
-  template <typename Type>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> operator-(const Vector3<Type>& a,
-                                                                        const Vector3<Type>& b) {
-    auto res = a;
-    res -= b;
-    return res;
-  }
-
-  template <typename Type>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> operator-(const Vector3<Type>& a) {
-    auto res = a;
-    res.x = -res.x;
-    res.y = -res.y;
-    res.z = -res.z;
-    return res;
-  }
-
-  template <typename Type, typename Scalar>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> operator*(const Vector3<Type>& vec, Scalar scalar) {
-    auto res = vec;
-    res *= scalar;
-    return res;
-  }
-
-  template <typename Type, typename Scalar>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> operator*(Scalar scalar, const Vector3<Type>& vec) {
-    return vec * scalar;
-  }
-
-  template <typename Type, typename Scalar>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> operator/(const Vector3<Type>& vec, Scalar scalar) {
-    auto res = vec;
-    res /= scalar;
-    return res;
-  }
-
-  template <typename Type> bool operator==(const Vector3<Type>& a, const Vector3<Type>& b) {
-    return a.x == b.x && a.y == b.y && a.z == b.z;
-  }
-
-  template <typename Type> bool operator!=(const Vector3<Type>& a, const Vector3<Type>& b) { return !(a == b); }
-
-  template <typename Type> std::ostream& operator<<(std::ostream& out, const Vector3<Type>& vec) {
-    out << "(" << vec.x << ", " << vec.y << ", " << vec.z << ")";
-    return out;
-  }
-
-  // assuming decart coordinate systems, get Vector coordinates in a new system, where uzVec is Oz unit vector
-  // coordinates in the old system.
-  template <typename Type>
-  std::enable_if_t<std::is_arithmetic_v<Type>, Vector3<Type>> RotateUz(const Vector3<Type> stVec,
-                                                                       const Vector3<Type> uzVec) {
-    // NewUzVector must be normalized !
-
-    Vector3<Type> res_vec;
-    double up = uzVec.x * uzVec.x + uzVec.y * uzVec.y;
-
-    if (up > 0) {
-      up = std::sqrt(up);
-      res_vec.x = (uzVec.x * uzVec.z * stVec.x - uzVec.y * stVec.y) / up + uzVec.x * stVec.z;
-      res_vec.y = (uzVec.y * uzVec.z * stVec.x + uzVec.x * stVec.y) / up + uzVec.y * stVec.z;
-      res_vec.z = -up * stVec.x + uzVec.z * stVec.z;
-    } else if (uzVec.z < 0.) {
-      res_vec.x = -stVec.x;
-      res_vec.y = stVec.y;
-      res_vec.z = -stVec.z;
-    }  // phi=0  teta=pi
-
-    return res_vec;
-  }
-
-  template <typename Type = double> class LorentzVectorImpl {
-   public:
-    union {
-      Type e;
-      Type t;
+    template <typename Type = double>
+    struct Vector3 {
+        Type x, y, z;
     };
-    Type x;
-    Type y;
-    Type z;
 
-   private:
-    using FieldPtr = Type LorentzVectorImpl::*;
+    template <typename Type>
+    Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec);
 
-    static constexpr std::array<FieldPtr, 4> kFields = {&LorentzVectorImpl::e, &LorentzVectorImpl::x,
-                                                        &LorentzVectorImpl::y, &LorentzVectorImpl::z};
+    template <typename Type = double>
+    class LorentzVectorImpl {
+      public:
+        union {
+            Type e;
+            Type t;
+        };
+        Type x;
+        Type y;
+        Type z;
 
-   public:
-    const Type& operator[](int i) const { return this->*kFields[i]; }
-    Type& operator[](int i) { return this->*kFields[i]; }
+      private:
+        using FieldPtr = Type LorentzVectorImpl::*;
 
-    LorentzVectorImpl& operator+=(const LorentzVectorImpl& other) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] += other.*kFields[i];
-      }
-      return *this;
+        static constexpr std::array<FieldPtr, 4> Fields = {&LorentzVectorImpl::e, &LorentzVectorImpl::x,
+                                                           &LorentzVectorImpl::y, &LorentzVectorImpl::z};
+
+      public:
+        const Type& operator[](int i) const {
+            return this->*Fields[i];
+        }
+        Type& operator[](int i) {
+            return this->*Fields[i];
+        }
+
+        LorentzVectorImpl& operator+=(const LorentzVectorImpl& other) {
+            for (size_t i = 0; i < Fields.size(); ++i) {
+                this->*Fields[i] += other.*Fields[i];
+            }
+            return *this;
+        }
+
+        LorentzVectorImpl& operator-=(const LorentzVectorImpl& other) {
+            for (size_t i = 0; i < Fields.size(); ++i) {
+                this->*Fields[i] -= other.*Fields[i];
+            }
+            return *this;
+        }
+
+        LorentzVectorImpl& operator*=(Type scalar) {
+            for (size_t i = 0; i < Fields.size(); ++i) {
+                this->*Fields[i] *= scalar;
+            }
+            return *this;
+        }
+
+        LorentzVectorImpl& operator/=(Type scalar) {
+            for (size_t i = 0; i < Fields.size(); ++i) {
+                this->*Fields[i] /= scalar;
+            }
+            return *this;
+        }
+
+        // bx by and bz are projections of beta
+        LorentzVectorImpl& Boost(Type bx, Type by, Type bz) {
+
+            auto b2 = bx * bx + by * by + bz * bz;
+
+            if (b2 >= 1) {
+                throw std::runtime_error("Boost faster than speed of light.");
+            }
+            if (b2 <= .95 or not IsSpaceLike()) {
+                Type ggamma = 1.0 / std::sqrt(1.0 - b2);
+                Type bp = bx * x + by * y + bz * z;
+                Type gamma2 = b2 > 0 ? (ggamma - 1.0) / b2 : 0.0;
+
+                x = x + gamma2 * bp * bx + ggamma * bx * t;
+                y = y + gamma2 * bp * by + ggamma * by * t;
+                z = z + gamma2 * bp * bz + ggamma * bz * t;
+                t = ggamma * (t + bp);
+
+                // for big betas use rapidities instead (B = R^-1B'R, where B' is axis boost (Oz here) and R is Rotation
+                // matrix for spatial part)
+            } else {
+                // calculate direction vector coordinates
+                Type b1 = std::sqrt(b2);
+                Vector3<Type> rVec{bx / b1, by / b1, bz / b1};
+                Vector3<Type> rBack = RotateUz({0, 0, 1}, rVec);
+
+                // rotate space vector so that boost direction is {0, 0, 1} in new coordinates
+                auto newCoord = RotateUz({x, y, z}, rVec);
+                x = newCoord.x, y = newCoord.y, z = newCoord.z;
+
+                BoostAxisRapidity(std::atanh(b1)); // boost along Oz
+                // rotate back
+                newCoord = RotateUz({x, y, z}, rBack);
+                x = newCoord.x, y = newCoord.y, z = newCoord.z;
+            }
+
+            return *this;
+        }
+
+        // axis from 1 to 3 correspond to x-y-z. Note: this gives correct results only if other axes components are
+        // zero.
+        // TODO: Throw an error otherwise
+        LorentzVectorImpl& BoostAxisRapidity(Type rapidity, uint32_t axis = 3u) {
+            if (axis > 3 or axis < 1) {
+                throw std::runtime_error("Wrong axis in boostAxis. 1 for x, 2 for y, 3 for z.");
+            }
+            if (not IsSpaceLike()) {
+                throw std::runtime_error(
+                    "Rapidity calculation only viable for space-like 4-vectors. Use boost() instead");
+            }
+            Type inv = std::sqrt(e * e - this->*Fields[axis] * this->*Fields[axis]);
+            Type rRapidity = rapidity + .5 * (std::log(e + this->*Fields[axis]) - std::log(e - this->*Fields[axis]));
+            e = inv * std::cosh(rRapidity);
+            this->*Fields[axis] = inv * std::sinh(rRapidity);
+
+            return *this;
+        }
+
+        Type Mag2() const {
+            return t * t - (x * x + y * y + z * z);
+        }
+        Type Mag() const {
+            return std::sqrt(Mag2());
+        }
+
+        bool IsSpaceLike() const {
+            return Mag2() > 0;
+        }
+        bool IsLightLike() const {
+            return Mag2() == 0;
+        }
+        bool IsTimeLike() const {
+            return Mag2() < 0;
+        }
+    };
+
+    template <typename Type>
+    LorentzVectorImpl<Type> operator+(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+        auto res = a;
+        res += b;
+        return res;
     }
 
-    LorentzVectorImpl& operator-=(const LorentzVectorImpl& other) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] -= other.*kFields[i];
-      }
-      return *this;
+    template <typename Type>
+    LorentzVectorImpl<Type> operator-(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+        auto res = a;
+        res -= b;
+        return res;
     }
 
-    LorentzVectorImpl& operator*=(Type scalar) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] *= scalar;
-      }
-      return *this;
+    template <typename Type, typename Scalar>
+    LorentzVectorImpl<Type> operator*(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
+        auto res = vec;
+        res *= scalar;
+        return res;
     }
 
-    LorentzVectorImpl& operator/=(Type scalar) {
-      for (size_t i = 0; i < kFields.size(); ++i) {
-        this->*kFields[i] /= scalar;
-      }
-      return *this;
+    template <typename Type, typename Scalar>
+    LorentzVectorImpl<Type> operator*(Scalar scalar, const LorentzVectorImpl<Type>& vec) {
+        return vec * scalar;
     }
 
-    // bx by and bz are projections of beta
-    LorentzVectorImpl& Boost(Type bx, Type by, Type bz) {
-      Type b2 = bx * bx + by * by + bz * bz;
-
-      if (b2 >= 1) {
-        throw std::runtime_error("Boost faster than speed of light.");
-      }
-      if (b2 <= .95 or not IsSpaceLike()) {
-        Type ggamma = 1.0 / std::sqrt(1.0 - b2);
-        Type bp = bx * x + by * y + bz * z;
-        Type gamma2 = b2 > 0 ? (ggamma - 1.0) / b2 : 0.0;
-
-        x = x + gamma2 * bp * bx + ggamma * bx * t;
-        y = y + gamma2 * bp * by + ggamma * by * t;
-        z = z + gamma2 * bp * bz + ggamma * bz * t;
-        t = ggamma * (t + bp);
-
-        // for big betas use rapidities instead (B = R^-1B'R, where B' is axis boost (Oz here) and R is Rotation
-        // matrix for spatial part)
-      } else {
-        // calculate direction vector coordinates
-        Type b1 = std::sqrt(b2);
-        Vector3<Type> r_vec{bx / b1, by / b1, bz / b1};
-        Vector3<Type> r_back = rotateUz({0, 0, 1}, r_vec);
-
-        // rotate space vector so that boost direction is {0, 0, 1} in new coordinates
-        auto new_coord = rotateUz({x, y, z}, r_vec);
-        x = new_coord.x, y = new_coord.y, z = new_coord.z;
-
-        BoostAxisRapidity(std::atanh(b1));  // boost along Oz
-        // rotate back
-        new_coord = rotateUz({x, y, z}, r_back);
-        x = new_coord.x, y = new_coord.y, z = new_coord.z;
-      }
-
-      return *this;
+    template <typename Type, typename Scalar>
+    LorentzVectorImpl<Type> operator/(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
+        auto res = vec;
+        res /= scalar;
+        return res;
     }
 
-    // axis from 1 to 3 correspond to x-y-z. Note: this gives correct results only if other axes components are
-    // zero. TODO: Throw an error otherwise
-    LorentzVectorImpl& BoostAxisRapidity(Type rapidity, uint axis = 3u) {
-      if (axis > 3 or axis < 1) {
-        throw std::runtime_error("Wrong axis in boostAxis. 1 for x, 2 for y, 3 for z.");
-      }
-      if (not IsSpaceLike()) {
-        throw std::runtime_error("Rapidity calculation only viable for space-like 4-vectors. Use boost() instead");
-      }
-      Type inv = std::sqrt(e * e - this->*kFields[axis] * this->*kFields[axis]);
-      Type r_rapidity = rapidity + .5 * (std::log(e + this->*kFields[axis]) - std::log(e - this->*kFields[axis]));
-      e = inv * std::cosh(r_rapidity);
-      this->*kFields[axis] = inv * std::sinh(r_rapidity);
-
-      return *this;
+    template <typename Type>
+    bool operator==(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+        return a.e == b.e && a.x == b.x && a.y == b.y && a.z == b.z;
     }
 
-    // boost by vector
-    LorentzVectorImpl& Boost(const LorentzVectorImpl& target) {
-      return boost(target.x / target.e, target.y / target.e, target.z / target.e);
+    template <typename Type>
+    bool operator!=(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+        return !(a == b);
     }
 
-    // extract spatial part
-    Vector3<Type> SpatialPart() const {
-      Vector3<Type> position;
-      position.x = x;
-      position.y = y;
-      position.z = z;
-      return position;
+    template <typename Type>
+    std::ostream& operator<<(std::ostream& out, const LorentzVectorImpl<Type>& vec) {
+        out << "(" << vec.e << ", " << vec.x << ", " << vec.y << ", " << vec.z << ")";
+        return out;
     }
 
-    Type Mag2() const { return t * t - (x * x + y * y + z * z); }
-    Type Mag() const { return std::sqrt(Mag2()); }
+    template <typename Type>
+    Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec) {
+        // NewUzVector must be normalized !
 
-    bool IsSpaceLike() const { return Mag2() > 0; }
-    bool IsLightLike() const { return Mag2() == 0; }
-    bool IsTimeLike() const { return Mag2() < 0; }
-  };
+        Vector3<Type> resVec;
+        auto up = uzVec.x * uzVec.x + uzVec.y * uzVec.y;
 
-  template <typename Type>
-  LorentzVectorImpl<Type> operator+(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-    auto res = a;
-    res += b;
-    return res;
-  }
+        if (up > 0) {
+            up = std::sqrt(up);
+            resVec.x = (uzVec.x * uzVec.z * stVec.x - uzVec.y * stVec.y) / up + uzVec.x * stVec.z;
+            resVec.y = (uzVec.y * uzVec.z * stVec.x + uzVec.x * stVec.y) / up + uzVec.y * stVec.z;
+            resVec.z = -up * stVec.x + uzVec.z * stVec.z;
+        } else if (uzVec.z < 0.) {
+            resVec.x = -stVec.x;
+            resVec.y = stVec.y;
+            resVec.z = -stVec.z;
+        } // phi=0  teta=pi
 
-  template <typename Type>
-  LorentzVectorImpl<Type> operator-(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-    auto res = a;
-    res -= b;
-    return res;
-  }
+        return resVec;
+    }
+} // namespace cola
 
-  // inverse momentum
-  template <typename Type> LorentzVectorImpl<Type> operator-(const LorentzVectorImpl<Type>& a) {
-    auto res = a;
-    res.x = -res.x;
-    res.y = -res.y;
-    res.z = -res.z;
-    return res;
-  }
-
-  template <typename Type, typename Scalar>
-  LorentzVectorImpl<Type> operator*(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
-    auto res = vec;
-    res *= scalar;
-    return res;
-  }
-
-  template <typename Type, typename Scalar>
-  LorentzVectorImpl<Type> operator*(Scalar scalar, const LorentzVectorImpl<Type>& vec) {
-    return vec * scalar;
-  }
-
-  template <typename Type, typename Scalar>
-  LorentzVectorImpl<Type> operator/(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
-    auto res = vec;
-    res /= scalar;
-    return res;
-  }
-
-  template <typename Type> bool operator==(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-    return a.e == b.e && a.x == b.x && a.y == b.y && a.z == b.z;
-  }
-
-  template <typename Type> bool operator!=(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-    return !(a == b);
-  }
-
-  template <typename Type> std::ostream& operator<<(std::ostream& out, const LorentzVectorImpl<Type>& vec) {
-    out << "(" << vec.e << ", " << vec.x << ", " << vec.y << ", " << vec.z << ")";
-    return out;
-  }
-}  // namespace cola
-
-#endif  // COLA_LORENTZVECTOR_HH
+#endif // COLA_LORENTZVECTOR_HH

--- a/LorentzVector.hh
+++ b/LorentzVector.hh
@@ -27,209 +27,187 @@
 
 namespace cola {
 
-    template <typename Type = double>
-    struct Vector3 {
-        Type x, y, z;
+  template <typename Type = double> struct Vector3 {
+    Type x, y, z;
+  };
+
+  template <typename Type = double> class LorentzVectorImpl {
+   public:
+    union {
+      Type e;
+      Type t;
     };
+    Type x;
+    Type y;
+    Type z;
 
-    template <typename Type = double>
-    class LorentzVectorImpl {
-      public:
-        union {
-            Type e;
-            Type t;
-        };
-        Type x;
-        Type y;
-        Type z;
+   private:
+    using FieldPtr = Type LorentzVectorImpl::*;
 
-      private:
-        using FieldPtr = Type LorentzVectorImpl::*;
+    static constexpr std::array<FieldPtr, 4> kFields = {&LorentzVectorImpl::e, &LorentzVectorImpl::x,
+                                                        &LorentzVectorImpl::y, &LorentzVectorImpl::z};
 
-        static constexpr std::array<FieldPtr, 4> FIELDS = {&LorentzVectorImpl::e, &LorentzVectorImpl::x,
-                                                           &LorentzVectorImpl::y, &LorentzVectorImpl::z};
+   public:
+    const Type& operator[](int i) const { return this->*kFields[i]; }
+    Type& operator[](int i) { return this->*kFields[i]; }
 
-      public:
-        const Type& operator[](int i) const {
-            return this->*FIELDS[i];
-        }
-        Type& operator[](int i) {
-            return this->*FIELDS[i];
-        }
-
-        LorentzVectorImpl& operator+=(const LorentzVectorImpl& other) {
-            for (size_t i = 0; i < FIELDS.size(); ++i) {
-                this->*FIELDS[i] += other.*FIELDS[i];
-            }
-            return *this;
-        }
-
-        LorentzVectorImpl& operator-=(const LorentzVectorImpl& other) {
-            for (size_t i = 0; i < FIELDS.size(); ++i) {
-                this->*FIELDS[i] -= other.*FIELDS[i];
-            }
-            return *this;
-        }
-
-        LorentzVectorImpl& operator*=(Type scalar) {
-            for (size_t i = 0; i < FIELDS.size(); ++i) {
-                this->*FIELDS[i] *= scalar;
-            }
-            return *this;
-        }
-
-        LorentzVectorImpl& operator/=(Type scalar) {
-            for (size_t i = 0; i < FIELDS.size(); ++i) {
-                this->*FIELDS[i] /= scalar;
-            }
-            return *this;
-        }
-
-        // bx by and bz are projections of beta
-        LorentzVectorImpl& Boost(Type bx, Type by, Type bz) {
-
-            auto b2 = bx * bx + by * by + bz * bz;
-
-            if (b2 >= 1) {
-                throw std::runtime_error("Boost faster than speed of light.");
-            }
-            if (b2 <= .95 or not IsSpaceLike()) {
-                Type ggamma = 1.0 / std::sqrt(1.0 - b2);
-                Type bp = bx * x + by * y + bz * z;
-                Type gamma2 = b2 > 0 ? (ggamma - 1.0) / b2 : 0.0;
-
-                x = x + gamma2 * bp * bx + ggamma * bx * t;
-                y = y + gamma2 * bp * by + ggamma * by * t;
-                z = z + gamma2 * bp * bz + ggamma * bz * t;
-                t = ggamma * (t + bp);
-
-                // for big betas use rapidities instead (B = R^-1B'R, where B' is axis boost (Oz here) and R is Rotation
-                // matrix for spatial part)
-            } else {
-                // calculate direction vector coordinates
-                Type b1 = std::sqrt(b2);
-                Vector3<Type> rVec{bx / b1, by / b1, bz / b1};
-                Vector3<Type> rBack = rotateUz({0, 0, 1}, rVec);
-
-                // rotate space vector so that boost direction is {0, 0, 1} in new coordinates
-                auto newCoord = rotateUz({x, y, z}, rVec);
-                x = newCoord.x, y = newCoord.y, z = newCoord.z;
-
-                BoostAxisRapidity(std::atanh(b1)); // boost along Oz
-                // rotate back
-                newCoord = rotateUz({x, y, z}, rBack);
-                x = newCoord.x, y = newCoord.y, z = newCoord.z;
-            }
-
-            return *this;
-        }
-
-        // axis from 1 to 3 correspond to x-y-z. Note: this gives correct results only if other axes components are
-        // zero.
-        // TODO: Throw an error otherwise
-        LorentzVectorImpl& BoostAxisRapidity(Type rapidity, uint32_t axis = 3u) {
-            if (axis > 3 or axis < 1) {
-                throw std::runtime_error("Wrong axis in boostAxis. 1 for x, 2 for y, 3 for z.");
-            }
-            if (not IsSpaceLike()) {
-                throw std::runtime_error(
-                    "Rapidity calculation only viable for space-like 4-vectors. Use boost() instead");
-            }
-            Type inv = std::sqrt(e * e - this->*FIELDS[axis] * this->*FIELDS[axis]);
-            Type rRapidity = rapidity + .5 * (std::log(e + this->*FIELDS[axis]) - std::log(e - this->*FIELDS[axis]));
-            e = inv * std::cosh(rRapidity);
-            this->*FIELDS[axis] = inv * std::sinh(rRapidity);
-
-            return *this;
-        }
-
-        Type Mag2() const {
-            return t * t - (x * x + y * y + z * z);
-        }
-        Type Mag() const {
-            return std::sqrt(Mag2());
-        }
-
-        bool IsSpaceLike() const {
-            return Mag2() > 0;
-        }
-        bool IsLightLike() const {
-            return Mag2() == 0;
-        }
-        bool IsTimeLike() const {
-            return Mag2() < 0;
-        }
-    };
-
-    template <typename Type>
-    LorentzVectorImpl<Type> operator+(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-        auto res = a;
-        res += b;
-        return res;
+    LorentzVectorImpl& operator+=(const LorentzVectorImpl& other) {
+      for (size_t i = 0; i < kFields.size(); ++i) {
+        this->*kFields[i] += other.*kFields[i];
+      }
+      return *this;
     }
 
-    template <typename Type>
-    LorentzVectorImpl<Type> operator-(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-        auto res = a;
-        res -= b;
-        return res;
+    LorentzVectorImpl& operator-=(const LorentzVectorImpl& other) {
+      for (size_t i = 0; i < kFields.size(); ++i) {
+        this->*kFields[i] -= other.*kFields[i];
+      }
+      return *this;
     }
 
-    template <typename Type, typename Scalar>
-    LorentzVectorImpl<Type> operator*(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
-        auto res = vec;
-        res *= scalar;
-        return res;
+    LorentzVectorImpl& operator*=(Type scalar) {
+      for (size_t i = 0; i < kFields.size(); ++i) {
+        this->*kFields[i] *= scalar;
+      }
+      return *this;
     }
 
-    template <typename Type, typename Scalar>
-    LorentzVectorImpl<Type> operator*(Scalar scalar, const LorentzVectorImpl<Type>& vec) {
-        return vec * scalar;
+    LorentzVectorImpl& operator/=(Type scalar) {
+      for (size_t i = 0; i < kFields.size(); ++i) {
+        this->*kFields[i] /= scalar;
+      }
+      return *this;
     }
 
-    template <typename Type, typename Scalar>
-    LorentzVectorImpl<Type> operator/(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
-        auto res = vec;
-        res /= scalar;
-        return res;
+    // bx by and bz are projections of beta
+    LorentzVectorImpl& Boost(Type bx, Type by, Type bz) {
+      auto b2 = bx * bx + by * by + bz * bz;
+
+      if (b2 >= 1) {
+        throw std::runtime_error("Boost faster than speed of light.");
+      }
+      if (b2 <= .95 or not IsSpaceLike()) {
+        Type ggamma = 1.0 / std::sqrt(1.0 - b2);
+        Type bp = bx * x + by * y + bz * z;
+        Type gamma2 = b2 > 0 ? (ggamma - 1.0) / b2 : 0.0;
+
+        x = x + gamma2 * bp * bx + ggamma * bx * t;
+        y = y + gamma2 * bp * by + ggamma * by * t;
+        z = z + gamma2 * bp * bz + ggamma * bz * t;
+        t = ggamma * (t + bp);
+
+        // for big betas use rapidities instead (B = R^-1B'R, where B' is axis boost (Oz here) and R is Rotation
+        // matrix for spatial part)
+      } else {
+        // calculate direction vector coordinates
+        Type b1 = std::sqrt(b2);
+        Vector3<Type> r_vec{bx / b1, by / b1, bz / b1};
+        Vector3<Type> r_back = rotateUz({0, 0, 1}, r_vec);
+
+        // rotate space vector so that boost direction is {0, 0, 1} in new coordinates
+        auto new_coord = rotateUz({x, y, z}, r_vec);
+        x = new_coord.x, y = new_coord.y, z = new_coord.z;
+
+        BoostAxisRapidity(std::atanh(b1));  // boost along Oz
+        // rotate back
+        new_coord = rotateUz({x, y, z}, r_back);
+        x = new_coord.x, y = new_coord.y, z = new_coord.z;
+      }
+
+      return *this;
     }
 
-    template <typename Type>
-    bool operator==(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-        return a.e == b.e && a.x == b.x && a.y == b.y && a.z == b.z;
+    // axis from 1 to 3 correspond to x-y-z. Note: this gives correct results only if other axes components are
+    // zero.
+    // TODO: Throw an error otherwise
+    LorentzVectorImpl& BoostAxisRapidity(Type rapidity, uint32_t axis = 3u) {
+      if (axis > 3 or axis < 1) {
+        throw std::runtime_error("Wrong axis in boostAxis. 1 for x, 2 for y, 3 for z.");
+      }
+      if (not IsSpaceLike()) {
+        throw std::runtime_error("Rapidity calculation only viable for space-like 4-vectors. Use boost() instead");
+      }
+      Type inv = std::sqrt(e * e - this->*kFields[axis] * this->*kFields[axis]);
+      Type r_rapidity = rapidity + .5 * (std::log(e + this->*kFields[axis]) - std::log(e - this->*kFields[axis]));
+      e = inv * std::cosh(r_rapidity);
+      this->*kFields[axis] = inv * std::sinh(r_rapidity);
+
+      return *this;
     }
 
-    template <typename Type>
-    bool operator!=(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
-        return !(a == b);
-    }
+    Type Mag2() const { return t * t - (x * x + y * y + z * z); }
+    Type Mag() const { return std::sqrt(Mag2()); }
 
-    template <typename Type>
-    std::ostream& operator<<(std::ostream& out, const LorentzVectorImpl<Type>& vec) {
-        out << "(" << vec.e << ", " << vec.x << ", " << vec.y << ", " << vec.z << ")";
-        return out;
-    }
+    bool IsSpaceLike() const { return Mag2() > 0; }
+    bool IsLightLike() const { return Mag2() == 0; }
+    bool IsTimeLike() const { return Mag2() < 0; }
+  };
 
-    template <typename Type>
-    Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec) {
-        // NewUzVector must be normalized !
+  template <typename Type>
+  LorentzVectorImpl<Type> operator+(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+    auto res = a;
+    res += b;
+    return res;
+  }
 
-        Vector3<Type> resVec;
-        auto up = uzVec.x * uzVec.x + uzVec.y * uzVec.y;
+  template <typename Type>
+  LorentzVectorImpl<Type> operator-(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+    auto res = a;
+    res -= b;
+    return res;
+  }
 
-        if (up > 0) {
-            up = std::sqrt(up);
-            resVec.x = (uzVec.x * uzVec.z * stVec.x - uzVec.y * stVec.y) / up + uzVec.x * stVec.z;
-            resVec.y = (uzVec.y * uzVec.z * stVec.x + uzVec.x * stVec.y) / up + uzVec.y * stVec.z;
-            resVec.z = -up * stVec.x + uzVec.z * stVec.z;
-        } else if (uzVec.z < 0.) {
-            resVec.x = -stVec.x;
-            resVec.y = stVec.y;
-            resVec.z = -stVec.z;
-        } // phi=0  teta=pi
+  template <typename Type, typename Scalar>
+  LorentzVectorImpl<Type> operator*(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
+    auto res = vec;
+    res *= scalar;
+    return res;
+  }
 
-        return resVec;
-    }
-} // namespace cola
+  template <typename Type, typename Scalar>
+  LorentzVectorImpl<Type> operator*(Scalar scalar, const LorentzVectorImpl<Type>& vec) {
+    return vec * scalar;
+  }
 
-#endif // COLA_LORENTZVECTOR_HH
+  template <typename Type, typename Scalar>
+  LorentzVectorImpl<Type> operator/(const LorentzVectorImpl<Type>& vec, Scalar scalar) {
+    auto res = vec;
+    res /= scalar;
+    return res;
+  }
+
+  template <typename Type> bool operator==(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+    return a.e == b.e && a.x == b.x && a.y == b.y && a.z == b.z;
+  }
+
+  template <typename Type> bool operator!=(const LorentzVectorImpl<Type>& a, const LorentzVectorImpl<Type>& b) {
+    return !(a == b);
+  }
+
+  template <typename Type> std::ostream& operator<<(std::ostream& out, const LorentzVectorImpl<Type>& vec) {
+    out << "(" << vec.e << ", " << vec.x << ", " << vec.y << ", " << vec.z << ")";
+    return out;
+  }
+
+  template <typename Type> Vector3<Type> RotateUz(const Vector3<Type> stVec, const Vector3<Type> uzVec) {
+    // NewUzVector must be normalized !
+
+    Vector3<Type> res_vec;
+    auto up = uzVec.x * uzVec.x + uzVec.y * uzVec.y;
+
+    if (up > 0) {
+      up = std::sqrt(up);
+      res_vec.x = (uzVec.x * uzVec.z * stVec.x - uzVec.y * stVec.y) / up + uzVec.x * stVec.z;
+      res_vec.y = (uzVec.y * uzVec.z * stVec.x + uzVec.x * stVec.y) / up + uzVec.y * stVec.z;
+      res_vec.z = -up * stVec.x + uzVec.z * stVec.z;
+    } else if (uzVec.z < 0.) {
+      res_vec.x = -stVec.x;
+      res_vec.y = stVec.y;
+      res_vec.z = -stVec.z;
+    }  // phi=0  teta=pi
+
+    return res_vec;
+  }
+}  // namespace cola
+
+#endif  // COLA_LORENTZVECTOR_HH

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # COLA - Nuclear COllision LAyout framework
 
+[![CI](https://github.com/Spectator-matter-group-INR-RAS/COLA/actions/workflows/ci.yml/badge.svg)](https://github.com/Spectator-matter-group-INR-RAS/COLA/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-Doxygen-2c5f7c)](https://github.com/Spectator-matter-group-INR-RAS/COLA/blob/main/README.md#documentation)
+
 Architectural framework for merging nucleus-nucleus collision models.
 
 ## Installation
@@ -16,7 +19,7 @@ cmake --build . --target install
 
 You can specify `CMAKE_INSTALL_PREFIX` to change the installation location (default for most Linux systems is `/usr/local`, which requires root)
 
-In the installation directory there is `config.sh` file, which should be sourced to add CMake package location to indexed directories list (in case the installation directory is not standart for the system). Consider adding it to `.profile` or `.bashrc`
+In the installation directory there is `config.sh` file, which should be sourced to add CMake package location to indexed directories list (in case the installation directory is not standard for the system). Consider adding it to `.profile` or `.bashrc`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Architectural framework for merging nucleus-nucleus collision models.
 
 ## Installation
 
-in source directory:
+In source directory:
 
 ```bash
 cd ../
@@ -19,7 +19,7 @@ cmake --build . --target install
 
 You can specify `CMAKE_INSTALL_PREFIX` to change the installation location (default for most Linux systems is `/usr/local`, which requires root)
 
-In the installation directory there is `config.sh` file, which should be sourced to add CMake package location to indexed directories list (in case the installation directory is not standard for the system). Consider adding it to `.profile` or `.bashrc`
+In the installation directory there is a `config.sh` file, which should be sourced to add CMake package location to indexed directories list (in case the installation directory is not standard for the system). Consider adding it to `.profile` or `.bashrc`
 
 ## Documentation
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,12 +16,10 @@
 # DAMAGES OR OTHER* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-enable_testing()
-
 find_package(GTest REQUIRED)
 include(GoogleTest)
 
-set(TEST_SRCS lorentz.cc)
+set(TEST_SRCS lorentz.cc cola_test.cc)
 
 add_executable(COLATest ${TEST_SRCS})
 set_target_properties(
@@ -30,6 +28,8 @@ set_target_properties(
                CXX_STANDARD_REQUIRED YES
                CXX_EXTENSIONS NO
                CXX_CLANG_TIDY "${COLA_CMAKE_CXX_CLANG_TIDY}"
+               BUILD_RPATH "${CMAKE_BINARY_DIR}"
+               BUILD_WITH_INSTALL_RPATH FALSE
 )
 
 target_link_libraries(COLATest COLA)

--- a/tests/cola_test.cc
+++ b/tests/cola_test.cc
@@ -29,6 +29,8 @@ using namespace cola;
 
 class TestGenerator : public VGenerator {
   public:
+    static inline const std::string NAME = "TestGenerator";
+
     int callCounter = 0;
     EventData referenceData = GetDefaultEventData();
 
@@ -60,6 +62,8 @@ class TestGenerator : public VGenerator {
 
 class TestConverter : public VConverter {
   public:
+    static inline const std::string NAME = "TestConverter";
+
     int callCounter = 0;
 
     std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) override {
@@ -74,6 +78,8 @@ class TestConverter : public VConverter {
 
 class TestWriter : public VWriter {
   public:
+    static inline const std::string NAME = "TestWriter";
+
     int callCounter = 0;
     std::vector<std::unique_ptr<EventData>> recordedEvents;
 
@@ -147,15 +153,15 @@ TEST(COLA_Parse, BadXMLContents) {
 TEST(COLA_Parse, NoGenerator) {
     auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
-        <converter name="test_converter"/>
-        <writer name="test_writer"/>
+        <converter name="TestConverter"/>
+        <writer name="TestWriter"/>
     </root>
     )");
 
     MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
     EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
 }
@@ -163,12 +169,12 @@ TEST(COLA_Parse, NoGenerator) {
 TEST(COLA_Parse, NoWriter) {
     auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
-        <generator name="test_generator"/>
+        <generator name="TestGenerator"/>
     </root>
     )");
 
     MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
 
     EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
 }
@@ -176,16 +182,16 @@ TEST(COLA_Parse, NoWriter) {
 TEST(COLA_Parse, MultipleGenerators) {
     auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
-        <generator name="test_generator"/>
-        <generator name="test_generator"/>
-        <writer name="test_writer"/>
+        <generator name="TestGenerator"/>
+        <generator name="TestGenerator"/>
+        <writer name="TestWriter"/>
     </root>
     )");
 
     MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
     EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
 }
@@ -193,16 +199,16 @@ TEST(COLA_Parse, MultipleGenerators) {
 TEST(COLA_Parse, MultipleWriters) {
     auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
-        <generator name="test_generator"/>
-        <writer name="test_writer"/>
-        <writer name="test_writer"/>
+        <generator name="TestGenerator"/>
+        <writer name="TestWriter"/>
+        <writer name="TestWriter"/>
     </root>
     )");
 
     MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
     EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
 }
@@ -271,16 +277,16 @@ TEST(ColaTest, StageHandling) {
 TEST(ColaTest, ParseAndRun) {
     auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
-        <generator name="test_generator"/>
-        <converter name="test_converter"/>
-        <writer name="test_writer"/>
+        <generator name="TestGenerator"/>
+        <converter name="TestConverter"/>
+        <writer name="TestWriter"/>
     </root>
     )");
 
     MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
     auto ensemble = processor.Parse(xmlStream);
 

--- a/tests/cola_test.cc
+++ b/tests/cola_test.cc
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) 2024-2025 Alexandr Svetlichnyi, Savva Savenkov, Artemii Novikov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+ * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <cstdint>
+#include <memory>
+#include <sstream>
+
+#include <COLA.hh>
+#include <gtest/gtest.h>
+
+using namespace cola;
+
+class TestGenerator : public VGenerator {
+  public:
+    int callCounter = 0;
+    EventData referenceData = GetDefaultEventData();
+
+    std::unique_ptr<EventData> operator()() override {
+        ++callCounter;
+
+        return std::make_unique<EventData>(referenceData);
+    }
+
+  private:
+    static constexpr EventData GetDefaultEventData() {
+        EventData event;
+        event.iniState.pdgCodeA = 1000010020;
+        event.iniState.pdgCodeB = 1000010020;
+        event.iniState.pZA = 1.0;
+        event.iniState.pZB = 0.0;
+        event.iniState.energy = 10.0;
+
+        Particle p1;
+        p1.pdgCode = cola::AZToPdg({1, 0});
+        p1.momentum = LorentzVector{.e = 1.0, .x = 0.1, .y = 0.2, .z = 0.3};
+        p1.position = LorentzVector{.e = 0.0, .x = 0.0, .y = 0.0, .z = 0.0};
+        p1.pClass = ParticleClass::PRODUCED;
+        event.particles.push_back(p1);
+
+        return event;
+    }
+};
+
+class TestConverter : public VConverter {
+  public:
+    int callCounter = 0;
+
+    std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) override {
+        ++callCounter;
+
+        for (auto& particle : data->particles) {
+            particle.momentum.x *= 2.0;
+        }
+        return data;
+    }
+};
+
+class TestWriter : public VWriter {
+  public:
+    int callCounter = 0;
+    std::vector<std::unique_ptr<EventData>> recordedEvents;
+
+    void operator()(std::unique_ptr<EventData>&& data) override {
+        ++callCounter;
+        recordedEvents.emplace_back(std::move(data));
+    }
+};
+
+template <typename T, typename... Args>
+void AppendMakeVector(std::vector<T>& results, T&& arg, Args&&... args) {
+    results.emplace_back(std::forward<T>(arg));
+    if constexpr (sizeof...(args) > 0) {
+        AppendMakeVector(results, std::forward<Args>(args)...);
+    }
+}
+
+template <typename T, typename... Args>
+std::vector<T> MakeVector(T&& arg, Args&&... args) {
+    std::vector<T> results;
+
+    AppendMakeVector(results, std::forward<T>(arg), std::forward<Args>(args)...);
+
+    return results;
+}
+
+TEST(COLA_PDG_Test, CircularConsistency) {
+    for (uint16_t atomicMass = 1; atomicMass < 100; ++atomicMass) {
+        for (uint16_t chargeNumber = 0; chargeNumber <= atomicMass; ++chargeNumber) {
+            auto pdgCode = cola::AZToPdg({atomicMass, chargeNumber});
+            auto [circularA, circularZ] = cola::PdgToAZ(pdgCode);
+            EXPECT_EQ(circularA, atomicMass) << "Failed conversion for A = " << atomicMass << ", Z = " << chargeNumber;
+            EXPECT_EQ(circularZ, chargeNumber)
+                << "Failed conversion for A = " << atomicMass << ", Z = " << chargeNumber;
+        }
+    }
+}
+
+TEST(COLA_PDG_Test, PDGToAZForNeutron) {
+    auto [a, z] = PdgToAZ(2112);
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(z, 0);
+}
+
+TEST(COLA_PDG_Test, PDGToAZForProton) {
+    auto [a, z] = PdgToAZ(2212);
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(z, 1);
+}
+
+TEST(COLA_PDG_Test, AZToPDGForNeutron) {
+    auto az = AZ{1, 0};
+    auto pdgCode = AZToPdg(az);
+    EXPECT_EQ(pdgCode, 2112);
+}
+
+TEST(COLA_Parse, InvalidFilePath) {
+    MetaProcessor processor;
+
+    EXPECT_THROW(processor.Parse("nonexistent/file.xml"), std::runtime_error);
+}
+
+TEST(COLA_Parse, BadXMLContents) {
+    auto badXMLStream = std::stringstream(R"(<?xml version="1.0"?><no end block>)");
+
+    MetaProcessor processor;
+
+    EXPECT_THROW(processor.Parse(badXMLStream), std::runtime_error);
+}
+
+TEST(COLA_Parse, NoGenerator) {
+    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+    <root>
+        <converter name="test_converter"/>
+        <writer name="test_writer"/>
+    </root>
+    )");
+
+    MetaProcessor processor;
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+
+    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+}
+
+TEST(COLA_Parse, NoWriter) {
+    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+    <root>
+        <generator name="test_generator"/>
+    </root>
+    )");
+
+    MetaProcessor processor;
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
+
+    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+}
+
+TEST(COLA_Parse, MultipleGenerators) {
+    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+    <root>
+        <generator name="test_generator"/>
+        <generator name="test_generator"/>
+        <writer name="test_writer"/>
+    </root>
+    )");
+
+    MetaProcessor processor;
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+
+    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+}
+
+TEST(COLA_Parse, MultipleWriters) {
+    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+    <root>
+        <generator name="test_generator"/>
+        <writer name="test_writer"/>
+        <writer name="test_writer"/>
+    </root>
+    )");
+
+    MetaProcessor processor;
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+
+    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+}
+
+TEST(COLA_Pipeline, RunPipeline) {
+    auto ensemble = FilterEnsemble{
+        .generator = std::make_unique<TestGenerator>(),
+        .converters = MakeVector(std::unique_ptr<VConverter>(new TestConverter)),
+        .writer = std::make_unique<TestWriter>(),
+    };
+    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+    auto* converterPtr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+
+    ColaRunManager manager(std::move(ensemble));
+    manager.Run(3);
+
+    EXPECT_EQ(generatorPtr->callCounter, 3);
+    EXPECT_EQ(converterPtr->callCounter, 3);
+    EXPECT_EQ(writerPtr->callCounter, 3);
+}
+
+TEST(ColaTest, MultipleConverters) {
+    auto ensemble = FilterEnsemble{
+        .generator = std::make_unique<TestGenerator>(),
+        .converters =
+            MakeVector(std::unique_ptr<VConverter>(new TestConverter), std::unique_ptr<VConverter>(new TestConverter)),
+        .writer = std::make_unique<TestWriter>(),
+    };
+    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+    auto* converterPtr1 = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+    auto* converterPtr2 = dynamic_cast<TestConverter*>(ensemble.converters[1].get());
+    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+
+    ColaRunManager manager(std::move(ensemble));
+    manager.Run(3);
+
+    EXPECT_EQ(generatorPtr->callCounter, 3);
+    EXPECT_EQ(converterPtr1->callCounter, 3);
+    EXPECT_EQ(converterPtr2->callCounter, 3);
+    EXPECT_EQ(writerPtr->callCounter, 3);
+}
+
+TEST(ColaTest, StageHandling) {
+    auto ensemble = FilterEnsemble{
+        .generator = std::make_unique<TestGenerator>(),
+        .converters = MakeVector(std::unique_ptr<VConverter>(new TestConverter)),
+        .writer = std::make_unique<TestWriter>(),
+    };
+    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+    auto* converterPtr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+
+    ColaRunManager manager(std::move(ensemble));
+    manager.Run(1);
+
+    EXPECT_EQ(generatorPtr->callCounter, 1);
+    EXPECT_EQ(converterPtr->callCounter, 1);
+    EXPECT_EQ(writerPtr->callCounter, 1);
+
+    ASSERT_GE(writerPtr->recordedEvents.size(), 1);
+    ASSERT_EQ(writerPtr->recordedEvents[0]->particles.size(), 1);
+    EXPECT_EQ(writerPtr->recordedEvents[0]->particles[0].pdgCode, cola::AZToPdg({1, 0}));
+}
+
+TEST(ColaTest, ParseAndRun) {
+    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+    <root>
+        <generator name="test_generator"/>
+        <converter name="test_converter"/>
+        <writer name="test_writer"/>
+    </root>
+    )");
+
+    MetaProcessor processor;
+    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "test_generator");
+    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "test_converter");
+    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "test_writer");
+
+    auto ensemble = processor.Parse(xmlStream);
+
+    ASSERT_EQ(ensemble.converters.size(), 1);
+
+    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+    auto* converterPtr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+
+    ColaRunManager manager(std::move(ensemble));
+    manager.Run(1);
+
+    EXPECT_EQ(generatorPtr->callCounter, 1);
+    EXPECT_EQ(converterPtr->callCounter, 1);
+    EXPECT_EQ(writerPtr->callCounter, 1);
+
+    ASSERT_GE(writerPtr->recordedEvents.size(), 1);
+    ASSERT_EQ(writerPtr->recordedEvents[0]->particles.size(), 1);
+    EXPECT_EQ(writerPtr->recordedEvents[0]->particles[0].pdgCode, cola::AZToPdg({1, 0}));
+}

--- a/tests/cola_test.cc
+++ b/tests/cola_test.cc
@@ -36,18 +36,17 @@ namespace {
       AppendMakeVector(results, std::forward<Args>(args)...);
     }
   }
-  
+
   template <typename T, typename... Args>
   std::vector<T> MakeVector(T&& arg, Args&&... args) {
     std::vector<T> results;
-  
+
     AppendMakeVector(results, std::forward<T>(arg), std::forward<Args>(args)...);
-  
+
     return results;
   }
-  
-  }  // namespace
-  
+
+}  // namespace
 
 class TestGenerator : public VGenerator {
  public:

--- a/tests/cola_test.cc
+++ b/tests/cola_test.cc
@@ -18,169 +18,173 @@
  * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <COLA.hh>
+#include <gtest/gtest.h>
+
 #include <cstdint>
 #include <memory>
 #include <sstream>
 
-#include <COLA.hh>
-#include <gtest/gtest.h>
-
 using namespace cola;
 
+namespace {
+
+  template <typename T, typename... Args>
+  void AppendMakeVector(std::vector<T>& results, T&& arg, Args&&... args) {
+    results.emplace_back(std::forward<T>(arg));
+    if constexpr (sizeof...(args) > 0) {
+      AppendMakeVector(results, std::forward<Args>(args)...);
+    }
+  }
+  
+  template <typename T, typename... Args>
+  std::vector<T> MakeVector(T&& arg, Args&&... args) {
+    std::vector<T> results;
+  
+    AppendMakeVector(results, std::forward<T>(arg), std::forward<Args>(args)...);
+  
+    return results;
+  }
+  
+  }  // namespace
+  
+
 class TestGenerator : public VGenerator {
-  public:
-    static inline const std::string NAME = "TestGenerator";
+ public:
+  static inline const std::string kName = "TestGenerator";
 
-    int callCounter = 0;
-    EventData referenceData = GetDefaultEventData();
+  int callCounter = 0;
+  EventData referenceData = GetDefaultEventData();
 
-    std::unique_ptr<EventData> operator()() override {
-        ++callCounter;
+  std::unique_ptr<EventData> operator()() override {
+    ++callCounter;
 
-        return std::make_unique<EventData>(referenceData);
-    }
+    return std::make_unique<EventData>(referenceData);
+  }
 
-  private:
-    static constexpr EventData GetDefaultEventData() {
-        EventData event;
-        event.iniState.pdgCodeA = 1000010020;
-        event.iniState.pdgCodeB = 1000010020;
-        event.iniState.pZA = 1.0;
-        event.iniState.pZB = 0.0;
-        event.iniState.energy = 10.0;
+ private:
+  static constexpr EventData GetDefaultEventData() {
+    EventData event;
+    event.iniState.pdgCodeA = 1000010020;
+    event.iniState.pdgCodeB = 1000010020;
+    event.iniState.pZA = 1.0;
+    event.iniState.pZB = 0.0;
+    event.iniState.energy = 10.0;
 
-        Particle p1;
-        p1.pdgCode = cola::AZToPdg({1, 0});
-        p1.momentum = LorentzVector{.e = 1.0, .x = 0.1, .y = 0.2, .z = 0.3};
-        p1.position = LorentzVector{.e = 0.0, .x = 0.0, .y = 0.0, .z = 0.0};
-        p1.pClass = ParticleClass::PRODUCED;
-        event.particles.push_back(p1);
+    Particle p1;
+    p1.pdgCode = cola::AZToPdg({1, 0});
+    p1.momentum = LorentzVector{.e = 1.0, .x = 0.1, .y = 0.2, .z = 0.3};
+    p1.position = LorentzVector{.e = 0.0, .x = 0.0, .y = 0.0, .z = 0.0};
+    p1.pClass = ParticleClass::kProduced;
+    event.particles.push_back(p1);
 
-        return event;
-    }
+    return event;
+  }
 };
 
 class TestConverter : public VConverter {
-  public:
-    static inline const std::string NAME = "TestConverter";
+ public:
+  static inline const std::string kName = "TestConverter";
 
-    int callCounter = 0;
+  int callCounter = 0;
 
-    std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) override {
-        ++callCounter;
+  std::unique_ptr<EventData> operator()(std::unique_ptr<EventData>&& data) override {
+    ++callCounter;
 
-        for (auto& particle : data->particles) {
-            particle.momentum.x *= 2.0;
-        }
-        return data;
+    for (auto& particle : data->particles) {
+      particle.momentum.x *= 2.0;
     }
+    return data;
+  }
 };
 
 class TestWriter : public VWriter {
-  public:
-    static inline const std::string NAME = "TestWriter";
+ public:
+  static inline const std::string kName = "TestWriter";
 
-    int callCounter = 0;
-    std::vector<std::unique_ptr<EventData>> recordedEvents;
+  int callCounter = 0;
+  std::vector<std::unique_ptr<EventData>> recordedEvents;
 
-    void operator()(std::unique_ptr<EventData>&& data) override {
-        ++callCounter;
-        recordedEvents.emplace_back(std::move(data));
-    }
+  void operator()(std::unique_ptr<EventData>&& data) override {
+    ++callCounter;
+    recordedEvents.emplace_back(std::move(data));
+  }
 };
 
-template <typename T, typename... Args>
-void AppendMakeVector(std::vector<T>& results, T&& arg, Args&&... args) {
-    results.emplace_back(std::forward<T>(arg));
-    if constexpr (sizeof...(args) > 0) {
-        AppendMakeVector(results, std::forward<Args>(args)...);
+TEST(ColaPdgTest, CircularConsistency) {
+  for (uint16_t atomic_mass = 1; atomic_mass < 100; ++atomic_mass) {
+    for (uint16_t charge_number = 0; charge_number <= atomic_mass; ++charge_number) {
+      auto pdg_code = cola::AZToPdg({atomic_mass, charge_number});
+      auto [circularA, circularZ] = cola::PdgToAZ(pdg_code);
+      EXPECT_EQ(circularA, atomic_mass) << "Failed conversion for A = " << atomic_mass << ", Z = " << charge_number;
+      EXPECT_EQ(circularZ, charge_number) << "Failed conversion for A = " << atomic_mass << ", Z = " << charge_number;
     }
+  }
 }
 
-template <typename T, typename... Args>
-std::vector<T> MakeVector(T&& arg, Args&&... args) {
-    std::vector<T> results;
-
-    AppendMakeVector(results, std::forward<T>(arg), std::forward<Args>(args)...);
-
-    return results;
+TEST(ColaPdgTest, PDGToAZForNeutron) {
+  auto [a, z] = PdgToAZ(2112);
+  EXPECT_EQ(a, 1);
+  EXPECT_EQ(z, 0);
 }
 
-TEST(COLA_PDG_Test, CircularConsistency) {
-    for (uint16_t atomicMass = 1; atomicMass < 100; ++atomicMass) {
-        for (uint16_t chargeNumber = 0; chargeNumber <= atomicMass; ++chargeNumber) {
-            auto pdgCode = cola::AZToPdg({atomicMass, chargeNumber});
-            auto [circularA, circularZ] = cola::PdgToAZ(pdgCode);
-            EXPECT_EQ(circularA, atomicMass) << "Failed conversion for A = " << atomicMass << ", Z = " << chargeNumber;
-            EXPECT_EQ(circularZ, chargeNumber)
-                << "Failed conversion for A = " << atomicMass << ", Z = " << chargeNumber;
-        }
-    }
+TEST(ColaPdgTest, PDGToAZForProton) {
+  auto [a, z] = PdgToAZ(2212);
+  EXPECT_EQ(a, 1);
+  EXPECT_EQ(z, 1);
 }
 
-TEST(COLA_PDG_Test, PDGToAZForNeutron) {
-    auto [a, z] = PdgToAZ(2112);
-    EXPECT_EQ(a, 1);
-    EXPECT_EQ(z, 0);
+TEST(ColaPdgTest, AZToPDGForNeutron) {
+  auto az = AZ{1, 0};
+  auto pdg_code = AZToPdg(az);
+  EXPECT_EQ(pdg_code, 2112);
 }
 
-TEST(COLA_PDG_Test, PDGToAZForProton) {
-    auto [a, z] = PdgToAZ(2212);
-    EXPECT_EQ(a, 1);
-    EXPECT_EQ(z, 1);
+TEST(ColaParse, InvalidFilePath) {
+  MetaProcessor processor;
+
+  EXPECT_THROW(processor.Parse("nonexistent/file.xml"), std::runtime_error);
 }
 
-TEST(COLA_PDG_Test, AZToPDGForNeutron) {
-    auto az = AZ{1, 0};
-    auto pdgCode = AZToPdg(az);
-    EXPECT_EQ(pdgCode, 2112);
+TEST(ColaParse, BadXMLContents) {
+  auto bad_xml_stream = std::stringstream(R"(<?xml version="1.0"?><no end block>)");
+
+  MetaProcessor processor;
+
+  EXPECT_THROW(processor.Parse(bad_xml_stream), std::runtime_error);
 }
 
-TEST(COLA_Parse, InvalidFilePath) {
-    MetaProcessor processor;
-
-    EXPECT_THROW(processor.Parse("nonexistent/file.xml"), std::runtime_error);
-}
-
-TEST(COLA_Parse, BadXMLContents) {
-    auto badXMLStream = std::stringstream(R"(<?xml version="1.0"?><no end block>)");
-
-    MetaProcessor processor;
-
-    EXPECT_THROW(processor.Parse(badXMLStream), std::runtime_error);
-}
-
-TEST(COLA_Parse, NoGenerator) {
-    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+TEST(ColaParse, NoGenerator) {
+  auto xml_stream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
         <converter name="TestConverter"/>
         <writer name="TestWriter"/>
     </root>
     )");
 
-    MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
+  MetaProcessor processor;
+  processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+  processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+  processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
-    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+  EXPECT_THROW(processor.Parse(xml_stream), std::runtime_error);
 }
 
-TEST(COLA_Parse, NoWriter) {
-    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+TEST(ColaParse, NoWriter) {
+  auto xml_stream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
         <generator name="TestGenerator"/>
     </root>
     )");
 
-    MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+  MetaProcessor processor;
+  processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
 
-    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+  EXPECT_THROW(processor.Parse(xml_stream), std::runtime_error);
 }
 
-TEST(COLA_Parse, MultipleGenerators) {
-    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+TEST(ColaParse, MultipleGenerators) {
+  auto xml_stream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
         <generator name="TestGenerator"/>
         <generator name="TestGenerator"/>
@@ -188,16 +192,16 @@ TEST(COLA_Parse, MultipleGenerators) {
     </root>
     )");
 
-    MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
+  MetaProcessor processor;
+  processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+  processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+  processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
-    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+  EXPECT_THROW(processor.Parse(xml_stream), std::runtime_error);
 }
 
-TEST(COLA_Parse, MultipleWriters) {
-    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+TEST(ColaParse, MultipleWriters) {
+  auto xml_stream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
         <generator name="TestGenerator"/>
         <writer name="TestWriter"/>
@@ -205,77 +209,77 @@ TEST(COLA_Parse, MultipleWriters) {
     </root>
     )");
 
-    MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
+  MetaProcessor processor;
+  processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+  processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+  processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
-    EXPECT_THROW(processor.Parse(xmlStream), std::runtime_error);
+  EXPECT_THROW(processor.Parse(xml_stream), std::runtime_error);
 }
 
-TEST(COLA_Pipeline, RunPipeline) {
-    auto ensemble = FilterEnsemble{
-        .generator = std::make_unique<TestGenerator>(),
-        .converters = MakeVector(std::unique_ptr<VConverter>(new TestConverter)),
-        .writer = std::make_unique<TestWriter>(),
-    };
-    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
-    auto* converterPtr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
-    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+TEST(ColaPipeline, RunPipeline) {
+  auto ensemble = FilterEnsemble{
+      .generator = std::make_unique<TestGenerator>(),
+      .converters = MakeVector(std::unique_ptr<VConverter>(new TestConverter)),
+      .writer = std::make_unique<TestWriter>(),
+  };
+  auto* generator_ptr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+  auto* converter_ptr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+  auto* writer_ptr = dynamic_cast<TestWriter*>(ensemble.writer.get());
 
-    ColaRunManager manager(std::move(ensemble));
-    manager.Run(3);
+  ColaRunManager manager(std::move(ensemble));
+  manager.Run(3);
 
-    EXPECT_EQ(generatorPtr->callCounter, 3);
-    EXPECT_EQ(converterPtr->callCounter, 3);
-    EXPECT_EQ(writerPtr->callCounter, 3);
+  EXPECT_EQ(generator_ptr->callCounter, 3);
+  EXPECT_EQ(converter_ptr->callCounter, 3);
+  EXPECT_EQ(writer_ptr->callCounter, 3);
 }
 
 TEST(ColaTest, MultipleConverters) {
-    auto ensemble = FilterEnsemble{
-        .generator = std::make_unique<TestGenerator>(),
-        .converters =
-            MakeVector(std::unique_ptr<VConverter>(new TestConverter), std::unique_ptr<VConverter>(new TestConverter)),
-        .writer = std::make_unique<TestWriter>(),
-    };
-    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
-    auto* converterPtr1 = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
-    auto* converterPtr2 = dynamic_cast<TestConverter*>(ensemble.converters[1].get());
-    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+  auto ensemble = FilterEnsemble{
+      .generator = std::make_unique<TestGenerator>(),
+      .converters =
+          MakeVector(std::unique_ptr<VConverter>(new TestConverter), std::unique_ptr<VConverter>(new TestConverter)),
+      .writer = std::make_unique<TestWriter>(),
+  };
+  auto* generator_ptr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+  auto* converter_ptr1 = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+  auto* converter_ptr2 = dynamic_cast<TestConverter*>(ensemble.converters[1].get());
+  auto* writer_ptr = dynamic_cast<TestWriter*>(ensemble.writer.get());
 
-    ColaRunManager manager(std::move(ensemble));
-    manager.Run(3);
+  ColaRunManager manager(std::move(ensemble));
+  manager.Run(3);
 
-    EXPECT_EQ(generatorPtr->callCounter, 3);
-    EXPECT_EQ(converterPtr1->callCounter, 3);
-    EXPECT_EQ(converterPtr2->callCounter, 3);
-    EXPECT_EQ(writerPtr->callCounter, 3);
+  EXPECT_EQ(generator_ptr->callCounter, 3);
+  EXPECT_EQ(converter_ptr1->callCounter, 3);
+  EXPECT_EQ(converter_ptr2->callCounter, 3);
+  EXPECT_EQ(writer_ptr->callCounter, 3);
 }
 
 TEST(ColaTest, StageHandling) {
-    auto ensemble = FilterEnsemble{
-        .generator = std::make_unique<TestGenerator>(),
-        .converters = MakeVector(std::unique_ptr<VConverter>(new TestConverter)),
-        .writer = std::make_unique<TestWriter>(),
-    };
-    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
-    auto* converterPtr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
-    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+  auto ensemble = FilterEnsemble{
+      .generator = std::make_unique<TestGenerator>(),
+      .converters = MakeVector(std::unique_ptr<VConverter>(new TestConverter)),
+      .writer = std::make_unique<TestWriter>(),
+  };
+  auto* generator_ptr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+  auto* converter_ptr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+  auto* writer_ptr = dynamic_cast<TestWriter*>(ensemble.writer.get());
 
-    ColaRunManager manager(std::move(ensemble));
-    manager.Run(1);
+  ColaRunManager manager(std::move(ensemble));
+  manager.Run(1);
 
-    EXPECT_EQ(generatorPtr->callCounter, 1);
-    EXPECT_EQ(converterPtr->callCounter, 1);
-    EXPECT_EQ(writerPtr->callCounter, 1);
+  EXPECT_EQ(generator_ptr->callCounter, 1);
+  EXPECT_EQ(converter_ptr->callCounter, 1);
+  EXPECT_EQ(writer_ptr->callCounter, 1);
 
-    ASSERT_GE(writerPtr->recordedEvents.size(), 1);
-    ASSERT_EQ(writerPtr->recordedEvents[0]->particles.size(), 1);
-    EXPECT_EQ(writerPtr->recordedEvents[0]->particles[0].pdgCode, cola::AZToPdg({1, 0}));
+  ASSERT_GE(writer_ptr->recordedEvents.size(), 1);
+  ASSERT_EQ(writer_ptr->recordedEvents[0]->particles.size(), 1);
+  EXPECT_EQ(writer_ptr->recordedEvents[0]->particles[0].pdgCode, cola::AZToPdg({1, 0}));
 }
 
 TEST(ColaTest, ParseAndRun) {
-    auto xmlStream = std::stringstream(R"(<?xml version="1.0"?>
+  auto xml_stream = std::stringstream(R"(<?xml version="1.0"?>
     <root>
         <generator name="TestGenerator"/>
         <converter name="TestConverter"/>
@@ -283,27 +287,27 @@ TEST(ColaTest, ParseAndRun) {
     </root>
     )");
 
-    MetaProcessor processor;
-    processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
-    processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
-    processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
+  MetaProcessor processor;
+  processor.Register(std::make_unique<GenericFactory<TestGenerator>>(), "TestGenerator");
+  processor.Register(std::make_unique<GenericFactory<TestConverter>>(), "TestConverter");
+  processor.Register(std::make_unique<GenericFactory<TestWriter>>(), "TestWriter");
 
-    auto ensemble = processor.Parse(xmlStream);
+  auto ensemble = processor.Parse(xml_stream);
 
-    ASSERT_EQ(ensemble.converters.size(), 1);
+  ASSERT_EQ(ensemble.converters.size(), 1);
 
-    auto* generatorPtr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
-    auto* converterPtr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
-    auto* writerPtr = dynamic_cast<TestWriter*>(ensemble.writer.get());
+  auto* generator_ptr = dynamic_cast<TestGenerator*>(ensemble.generator.get());
+  auto* converter_ptr = dynamic_cast<TestConverter*>(ensemble.converters[0].get());
+  auto* writer_ptr = dynamic_cast<TestWriter*>(ensemble.writer.get());
 
-    ColaRunManager manager(std::move(ensemble));
-    manager.Run(1);
+  ColaRunManager manager(std::move(ensemble));
+  manager.Run(1);
 
-    EXPECT_EQ(generatorPtr->callCounter, 1);
-    EXPECT_EQ(converterPtr->callCounter, 1);
-    EXPECT_EQ(writerPtr->callCounter, 1);
+  EXPECT_EQ(generator_ptr->callCounter, 1);
+  EXPECT_EQ(converter_ptr->callCounter, 1);
+  EXPECT_EQ(writer_ptr->callCounter, 1);
 
-    ASSERT_GE(writerPtr->recordedEvents.size(), 1);
-    ASSERT_EQ(writerPtr->recordedEvents[0]->particles.size(), 1);
-    EXPECT_EQ(writerPtr->recordedEvents[0]->particles[0].pdgCode, cola::AZToPdg({1, 0}));
+  ASSERT_GE(writer_ptr->recordedEvents.size(), 1);
+  ASSERT_EQ(writer_ptr->recordedEvents[0]->particles.size(), 1);
+  EXPECT_EQ(writer_ptr->recordedEvents[0]->particles[0].pdgCode, cola::AZToPdg({1, 0}));
 }

--- a/tests/lorentz.cc
+++ b/tests/lorentz.cc
@@ -18,57 +18,56 @@
  * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <COLA.hh>
+#include <gtest/gtest.h>
+
 #include <cmath>
 #include <sstream>
-
-#include <COLA.hh>
-
-#include <gtest/gtest.h>
 
 using namespace cola;
 
 TEST(LorentzVector, Basic) {
-    LorentzVector vec{.e = 5, .x = 1, .y = 2, .z = 3};
+  LorentzVector vec{.e = 5, .x = 1, .y = 2, .z = 3};
 
-    EXPECT_EQ(vec.t, vec.e);
+  EXPECT_EQ(vec.t, vec.e);
 
-    EXPECT_EQ(vec[0], vec.e);
-    EXPECT_EQ(vec[1], vec.x);
-    EXPECT_EQ(vec[2], vec.y);
-    EXPECT_EQ(vec[3], vec.z);
+  EXPECT_EQ(vec[0], vec.e);
+  EXPECT_EQ(vec[1], vec.x);
+  EXPECT_EQ(vec[2], vec.y);
+  EXPECT_EQ(vec[3], vec.z);
 
-    EXPECT_EQ(vec.Mag2(), 5 * 5 - (1 * 1 + 2 * 2 + 3 * 3));
-    EXPECT_EQ(vec.Mag(), std::sqrt(5 * 5 - (1 * 1 + 2 * 2 + 3 * 3)));
-    EXPECT_TRUE(vec.IsSpaceLike());
+  EXPECT_EQ(vec.Mag2(), 5 * 5 - (1 * 1 + 2 * 2 + 3 * 3));
+  EXPECT_EQ(vec.Mag(), std::sqrt(5 * 5 - (1 * 1 + 2 * 2 + 3 * 3)));
+  EXPECT_TRUE(vec.IsSpaceLike());
 }
 
 TEST(LorentzVector, Arithmetic) {
-    LorentzVector vec1{.e = 0, .x = 1, .y = 2, .z = 3};
+  LorentzVector vec1{.e = 0, .x = 1, .y = 2, .z = 3};
 
-    LorentzVector vec2{.e = 4, .x = 3, .y = 2, .z = 1};
+  LorentzVector vec2{.e = 4, .x = 3, .y = 2, .z = 1};
 
-    {
-        auto expected = LorentzVector{.e = 4, .x = 4, .y = 4, .z = 4};
-        EXPECT_EQ(vec1 + vec2, expected);
-    }
+  {
+    auto expected = LorentzVector{.e = 4, .x = 4, .y = 4, .z = 4};
+    EXPECT_EQ(vec1 + vec2, expected);
+  }
 
-    {
-        auto expected = LorentzVector{.e = -4, .x = -2, .y = 0, .z = 2};
-        EXPECT_EQ(vec1 - vec2, expected);
-    }
+  {
+    auto expected = LorentzVector{.e = -4, .x = -2, .y = 0, .z = 2};
+    EXPECT_EQ(vec1 - vec2, expected);
+  }
 
-    {
-        auto expected = LorentzVector{.e = 0, .x = 3, .y = 6, .z = 9};
-        EXPECT_EQ(vec1 * 3, expected);
-        EXPECT_EQ(3 * vec1, expected);
-    }
+  {
+    auto expected = LorentzVector{.e = 0, .x = 3, .y = 6, .z = 9};
+    EXPECT_EQ(vec1 * 3, expected);
+    EXPECT_EQ(3 * vec1, expected);
+  }
 
-    {
-        auto expected = LorentzVector{.e = 2, .x = 2, .y = 2, .z = 2};
-        EXPECT_EQ((vec1 + vec2) / 2, expected);
-    }
+  {
+    auto expected = LorentzVector{.e = 2, .x = 2, .y = 2, .z = 2};
+    EXPECT_EQ((vec1 + vec2) / 2, expected);
+  }
 
-    std::stringstream ss;
-    ss << vec1;
-    EXPECT_EQ(ss.str(), "(0, 1, 2, 3)");
+  std::stringstream ss;
+  ss << vec1;
+  EXPECT_EQ(ss.str(), "(0, 1, 2, 3)");
 }

--- a/tests/lorentz.cc
+++ b/tests/lorentz.cc
@@ -18,56 +18,57 @@
  * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <COLA.hh>
-#include <gtest/gtest.h>
-
 #include <cmath>
 #include <sstream>
+
+#include <COLA.hh>
+
+#include <gtest/gtest.h>
 
 using namespace cola;
 
 TEST(LorentzVector, Basic) {
-  LorentzVector vec{.e = 5, .x = 1, .y = 2, .z = 3};
+    LorentzVector vec{.e = 5, .x = 1, .y = 2, .z = 3};
 
-  EXPECT_EQ(vec.t, vec.e);
+    EXPECT_EQ(vec.t, vec.e);
 
-  EXPECT_EQ(vec[0], vec.e);
-  EXPECT_EQ(vec[1], vec.x);
-  EXPECT_EQ(vec[2], vec.y);
-  EXPECT_EQ(vec[3], vec.z);
+    EXPECT_EQ(vec[0], vec.e);
+    EXPECT_EQ(vec[1], vec.x);
+    EXPECT_EQ(vec[2], vec.y);
+    EXPECT_EQ(vec[3], vec.z);
 
-  EXPECT_EQ(vec.Mag2(), 5 * 5 - (1 * 1 + 2 * 2 + 3 * 3));
-  EXPECT_EQ(vec.Mag(), std::sqrt(5 * 5 - (1 * 1 + 2 * 2 + 3 * 3)));
-  EXPECT_TRUE(vec.IsSpaceLike());
+    EXPECT_EQ(vec.Mag2(), 5 * 5 - (1 * 1 + 2 * 2 + 3 * 3));
+    EXPECT_EQ(vec.Mag(), std::sqrt(5 * 5 - (1 * 1 + 2 * 2 + 3 * 3)));
+    EXPECT_TRUE(vec.IsSpaceLike());
 }
 
 TEST(LorentzVector, Arithmetic) {
-  LorentzVector vec1{.e = 0, .x = 1, .y = 2, .z = 3};
+    LorentzVector vec1{.e = 0, .x = 1, .y = 2, .z = 3};
 
-  LorentzVector vec2{.e = 4, .x = 3, .y = 2, .z = 1};
+    LorentzVector vec2{.e = 4, .x = 3, .y = 2, .z = 1};
 
-  {
-    auto expected = LorentzVector{.e = 4, .x = 4, .y = 4, .z = 4};
-    EXPECT_EQ(vec1 + vec2, expected);
-  }
+    {
+        auto expected = LorentzVector{.e = 4, .x = 4, .y = 4, .z = 4};
+        EXPECT_EQ(vec1 + vec2, expected);
+    }
 
-  {
-    auto expected = LorentzVector{.e = -4, .x = -2, .y = 0, .z = 2};
-    EXPECT_EQ(vec1 - vec2, expected);
-  }
+    {
+        auto expected = LorentzVector{.e = -4, .x = -2, .y = 0, .z = 2};
+        EXPECT_EQ(vec1 - vec2, expected);
+    }
 
-  {
-    auto expected = LorentzVector{.e = 0, .x = 3, .y = 6, .z = 9};
-    EXPECT_EQ(vec1 * 3, expected);
-    EXPECT_EQ(3 * vec1, expected);
-  }
+    {
+        auto expected = LorentzVector{.e = 0, .x = 3, .y = 6, .z = 9};
+        EXPECT_EQ(vec1 * 3, expected);
+        EXPECT_EQ(3 * vec1, expected);
+    }
 
-  {
-    auto expected = LorentzVector{.e = 2, .x = 2, .y = 2, .z = 2};
-    EXPECT_EQ((vec1 + vec2) / 2, expected);
-  }
+    {
+        auto expected = LorentzVector{.e = 2, .x = 2, .y = 2, .z = 2};
+        EXPECT_EQ((vec1 + vec2) / 2, expected);
+    }
 
-  std::stringstream ss;
-  ss << vec1;
-  EXPECT_EQ(ss.str(), "(0, 1, 2, 3)");
+    std::stringstream ss;
+    ss << vec1;
+    EXPECT_EQ(ss.str(), "(0, 1, 2, 3)");
 }

--- a/tests/lorentz.cc
+++ b/tests/lorentz.cc
@@ -18,7 +18,7 @@
  * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <COLA.hh>
+#include <COLA/EventData.hh>
 #include <gtest/gtest.h>
 
 #include <cmath>


### PR DESCRIPTION
- Split header (required for SWIG to work properly)
- Loading modules as shared libs at runtime (required for build system to work with python)
- unordered_map instead of map (we don't need order)
- Automatic name and type deduction
- Make function names more verbose
- Improve performance with common constexpr functions